### PR TITLE
Further fixes to the default CRW Custom Resource

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -91,9 +91,9 @@ spec:
     # password for keycloak database user. Auto generated if left blank
     keycloakPostgresPassword: ''
     # desired admin username of Keycloak admin user (applicable only when externalIdentityProvider is false)
-    identityProviderAdminUserName: ''
+    identityProviderAdminUserName: 'admin'
     # desired password of Keycloak admin user (applicable only when externalIdentityProvider is false)
-    identityProviderPassword: 'admin'
+    identityProviderPassword: ''
     # name of a keycloak realm. This realm will be created, when externalIdentityProvider is true, otherwise passed to Che server
     identityProviderRealm: ''
     # id of a keycloak client. This client will be created, when externalIdentityProvider is false, otherwise passed to Che server

--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -52,10 +52,6 @@ spec:
     serverMemoryLimit: ''
     customCheProperties:
       CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY: 'Always'
-      CHE_DOCKER_ALWAYS__PULL__IMAGE: 'true'
-      CHE_WORKSPACE_PLUGIN__BROKER_INIT_IMAGE: 'quay.io/crw/pluginbrokerinit-rhel8:latest'
-      CHE_WORKSPACE_PLUGIN__BROKER_UNIFIED_IMAGE: 'quay.io/crw/pluginbroker-rhel8:latest'
-      CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: 'quay.io/crw/jwtproxy-rhel8:latest'
   database:
     # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
     # otherwise a Postgres deployment is created


### PR DESCRIPTION
This PR provides several fixes to the default CRW Custom Resource:
- remove the fixed image of the jwt-proxy, and plugin broker images, now that issue https://issues.jboss.org/browse/CRW-468 has been fixed by PR https://github.com/eclipse/che-operator/pull/115/files
- Fix a bug produced by buggy `auth` fields where we name and password were mixed