### PR TITLE
Use the `Always` pull policy for the operator, since the `2.0` tag is a moving tag for now

### DIFF
--- a/controller-manifests/v2.0.0/codeready-workspaces.2.0.0.clusterserviceversion.yaml
+++ b/controller-manifests/v2.0.0/codeready-workspaces.2.0.0.clusterserviceversion.yaml
@@ -289,7 +289,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: codeready-operator
                 image: registry.redhat.io/codeready-workspaces/server-operator-rhel8:2.0
-                imagePullPolicy: IfNotPresent
+                imagePullPolicy: Always
                 name: codeready-operator
                 ports:
                 - containerPort: 60000


### PR DESCRIPTION
Use the `Always` pull policy for the operator, since the `2.0` tag is a moving tag for now
(before the release)

Signed-off-by: David Festal <dfestal@redhat.com>