### PR TITLE
Use `quay.io/crw` operator image for now

### DIFF
--- a/controller-manifests/v2.0.0/codeready-workspaces.2.0.0.clusterserviceversion.yaml
+++ b/controller-manifests/v2.0.0/codeready-workspaces.2.0.0.clusterserviceversion.yaml
@@ -46,7 +46,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools, OpenShift Optional
     certified: "true"
-    containerImage: registry.redhat.io/codeready-workspaces/server-operator-rhel8:2.0
+    containerImage: quay.io/crw/operator-rhel8:2.0
     createdAt: 2019-10-29T11:59:59Z
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
@@ -288,7 +288,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: codeready-operator
-                image: registry.redhat.io/codeready-workspaces/server-operator-rhel8:2.0
+                image: quay.io/crw/operator-rhel8:2.0
                 imagePullPolicy: Always
                 name: codeready-operator
                 ports:


### PR DESCRIPTION
For now we should use the existing `quay.io/crw`-based docker image of the operator to continue testing until release

Signed-off-by: David Festal <dfestal@redhat.com>