### PR TITLE
Update channels according to Stevan choice

### DIFF
--- a/controller-manifests/codeready-workspaces.package.yaml
+++ b/controller-manifests/codeready-workspaces.package.yaml
@@ -1,7 +1,7 @@
 packageName: codeready-workspaces
 channels:
-- name: stable
+- name: latest
   currentCSV: crwoperator.v2.0.0
-- name: legacy
+- name: previous
   currentCSV: crwoperator.v1.2.2
-defaultChannel: stable
+defaultChannel: latest

--- a/controller-manifests/v1.2.2/codeready-workspaces.1.2.2.clusterserviceversion.yaml
+++ b/controller-manifests/v1.2.2/codeready-workspaces.1.2.2.clusterserviceversion.yaml
@@ -211,7 +211,7 @@ spec:
       type: MultiNamespace
     - supported: false
       type: AllNamespaces
-  version: 1.2.0
+  version: 1.2.2
   maintainers:
     - email: nboldt@redhat.com
       name: Nick Boldt


### PR DESCRIPTION
The channel names should be changed, so that the 2.0 channel would be *before* the 1.2 channel in alphabetci order.
This is a current constraint of OperatorHub so that the 2.0 CSV information would appear in the OperatorHub operator description.

`stable` vs `legacy` don't satisfy this constraint.

According to those constraints, the channels chosen by Stevan are:
- `latest` for 2.0 and following releases
- `previous` for 1.2 and following minor releases.