### PR TITLE
Return "per-workspace" default pvc strategy

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -76,7 +76,7 @@ spec:
   storage:
     # persistent volume claim strategy for Che server. Can be common (all workspaces PVCs in one volume),
     # per-workspace (one PVC per workspace for all declared volumes) and unique (one PVC per declared volume). Defaults to common
-    pvcStrategy: 'common'
+    pvcStrategy: 'per-workspace'
     # size of a persistent volume claim for workspaces. Defaults to 1Gi
     pvcClaimSize: '1Gi'
     # instruct Che server to launch a special pod to precreate a subpath in a PV


### PR DESCRIPTION
We had decided to switch to "per-workspace" strategy in CRW 1.x because PVC had RWO access mode on OSD by default, on OCP  deployed to AWS, and It made it impossible to run several workspaces at a time with "common" or "unique" PVC strategy.
https://issues.redhat.com/browse/CRW-73

We had faced this problem yesterday on QE OCP instances deployed to AWS.