### PR TITLE
Set tls support enabled by default

### DIFF
--- a/deploy/crds/org_v1_che_cr.yaml
+++ b/deploy/crds/org_v1_che_cr.yaml
@@ -37,7 +37,7 @@ spec:
     ## will be propagated to the Che components and provide particular configuration for Git.
     gitSelfSignedCert: false
     # TLS mode for Che. Make sure you either have public cert, or set selfSignedCert to true
-    tlsSupport: false
+    tlsSupport: true
     # protocol+hostname of a proxy server. Automatically added as JAVA_OPTS and https(s)_proxy
     # to Che server and workspaces containers
     proxyURL: ''


### PR DESCRIPTION
### What does this PR do?
It was decided to have TLS support enabled by default upstream starting from che-server of 7.9.1 version: https://github.com/eclipse/che-operator/blob/crw-2.1/deploy/crds/org_v1_che_cr.yaml#L40
