### PR TITLE
Make the CSV-related CRD schema OS 4.3 compatible

### DIFF
--- a/controller-manifests/v2.1.1/codeready-workspaces.crd.yaml
+++ b/controller-manifests/v2.1.1/codeready-workspaces.crd.yaml
@@ -22,8 +22,10 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
### What does this PR do?

Make the CSV-related CRD schema OS 4.3 compatible (structural schema).

This will allow getting back language services (completion / docs) on the `CheCluster` custom resource in the OpenShift Console for OpenShift 4.3 +

### What issues does this PR fix or reference?

This fix relates to the following issue: https://issues.redhat.com/browse/CRW-823