### PR TITLE
Remove che-tls-secret-creator image reference

### DIFF
--- a/deploy/operator-local.yaml
+++ b/deploy/operator-local.yaml
@@ -51,8 +51,6 @@ spec:
               value: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8:2.2
             - name: IMAGE_default_devfile_registry
               value: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:2.2
-            - name: IMAGE_default_che_tls_secrets_creation_job
-              value: quay.io/eclipse/che-tls-secret-creator:alpine-3029769
             - name: IMAGE_default_pvc_jobs
               value: registry.access.redhat.com/ubi8-minimal:8.2
             - name: IMAGE_default_postgres

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -50,8 +50,6 @@ spec:
               value: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8:2.2
             - name: IMAGE_default_devfile_registry
               value: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:2.2
-            - name: IMAGE_default_che_tls_secrets_creation_job
-              value: quay.io/eclipse/che-tls-secret-creator:alpine-3029769
             - name: IMAGE_default_pvc_jobs
               value: registry.access.redhat.com/ubi8-minimal:8.2
             - name: IMAGE_default_postgres


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Removes `che-tls-secret-creator ` image reference as it is used only on Kubernetes family infrastructures.

### What issues does this PR fix or reference?
Fixes https://issues.redhat.com/browse/CRW-977