### PR TITLE
CRW-927 Adding servicemonitor and view rb required for enabling OpenShift cluster monitoring for the 'openshift-workspaces' namespace

### DIFF
--- a/controller-manifests/v2.3.0/rb.yaml
+++ b/controller-manifests/v2.3.0/rb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: view-openshift-monitoring-prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/controller-manifests/v2.3.0/servicemonitor.yaml
+++ b/controller-manifests/v2.3.0/servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: openshift-workspaces-metrics-exporter
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - openshift-workspaces
+  selector:
+    matchLabels:
+      component: codeready

--- a/manifests/rb.yaml
+++ b/manifests/rb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: view-openshift-monitoring-prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/manifests/servicemonitor.yaml
+++ b/manifests/servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: openshift-workspaces-metrics-exporter
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - openshift-workspaces
+  selector:
+    matchLabels:
+      component: codeready


### PR DESCRIPTION
### What does this PR do?
Adding servicemonitor and view rb required for enabling OpenShift cluster monitoring for the 'openshift-workspaces' namespace

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-927

the first step was to use the suggested names and enable cluster monitoring in 2.3 csv:

```
    operatorframework.io/suggested-namespace: openshift-workspaces
    operatorframework.io/cluster-monitoring: "true"
```

![image](https://user-images.githubusercontent.com/1461122/88798747-af5ae480-d1a5-11ea-8ee1-a499c72b3a57.png)


https://github.com/redhat-developer/codeready-workspaces-operator/blob/master/controller-manifests/v2.3.0/codeready-workspaces.csv.yaml#L56-L57

This PR is the second step:
 - adding servicemonitor
 - ading view rb

This allows to see the che specific metrics via OpenShift cluster monitoring (opinionated Prometheus deployed in the 'openshift-monitoring' namespace)

![che-cluster-metrics](https://user-images.githubusercontent.com/1461122/88786006-3900b700-d192-11ea-9344-e6465aa21471.gif)

The next step  is to proceed with cardinality testing and making some metrics available on telemeter

#### Release Notes
N/A

#### Docs PR (if applicable)
N/A