### PR TITLE
CRW-1162 replace refs to...

### DIFF
--- a/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -110,7 +110,6 @@ for CSVFILE in \
 		-e 's|"pluginRegistryImage":.".+"|"pluginRegistryImage": ""|' \
 		-e 's|"identityProviderImage":.".+"|"identityProviderImage": ""|' \
 		\
-		-e "s|quay.io/eclipse/codeready-operator:${CHE_VERSION}|registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:${CRW_TAG}|" \
 		-e "s|quay.io/eclipse/che-server:.+|registry.redhat.io/codeready-workspaces/server-rhel8:${CRW_TAG}|" \
 		-e "s|quay.io/eclipse/che-plugin-registry:.+|registry.redhat.io/codeready-workspaces/pluginregistry-rhel8:${CRW_TAG}|" \
 		-e "s|quay.io/eclipse/che-devfile-registry:.+|registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:${CRW_TAG}|" \
@@ -123,6 +122,8 @@ for CSVFILE in \
 		-e "s|quay.io/eclipse/che-keycloak:.+|registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4|" \
 		-e "s|quay.io/eclipse/codeready-operator:nightly|registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:${CRW_TAG}|" \
 		-e "s|quay.io/eclipse/codeready-operator:${CHE_VERSION}|registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:${CRW_TAG}|" \
+		` # CRW-1162 replace any internal ref to operator with correct ref to crw-2-rhel8-operator` \
+		-e "s|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:.+|registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:${CRW_TAG}|" \
 		-e 's|IMAGE_default_|RELATED_IMAGE_|' \
 		\
 		` # CRW-927 set suggested namespace, append cluster-monitoring = true (removed from upstream as not supported in community operators)` \

--- a/operator-metadata.Jenkinsfile
+++ b/operator-metadata.Jenkinsfile
@@ -223,9 +223,11 @@ pushd ${WORKSPACE}/targetdwn >/dev/null
 popd >/dev/null
 
 # 3. revert to OSBS image refs, since digest pinning will automatically switch them to RHCC values
-sed -r \
-    -e "s#(quay.io/crw/|registry.redhat.io/codeready-workspaces/)#registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-#g" \
-    -i "${CSV_FILE}"
+# TODO CRW-1162 re-enable when using OSBS digest pinning, not homegrown variant
+#sed -r \
+#    -e "s#(quay.io/crw/|registry.redhat.io/codeready-workspaces/)#registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-#g" \
+#    -i "${CSV_FILE}"
+
 # TODO CRW-1044 switch to operators.operatorframework.io.bundle LABELs
 METADATA='ENV SUMMARY="Red Hat CodeReady Workspaces ''' + QUAY_PROJECT + ''' container" \\\r
     DESCRIPTION="Red Hat CodeReady Workspaces ''' + QUAY_PROJECT + ''' container" \\\r


### PR DESCRIPTION
CRW-1162 replace refs to registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator with registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator

Change-Id: I35b12c2fd361c63e5731f6f8e6227b5c0da2ca94
Signed-off-by: nickboldt <nboldt@redhat.com>