### PR TITLE
CRW-1202 re-enable addDigests.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+generated/

--- a/build/scripts/buildDigestMapAlternateURLs.sh
+++ b/build/scripts/buildDigestMapAlternateURLs.sh
@@ -1,19 +1,19 @@
-        if [[ ! "${QUIET}" ]]; then echo -n "[WARNING] Could not retrieve digest for '${image}'. Use alt URL: "; fi
+        if [[ ! "${QUIET}" ]]; then echo -n "[INFO] + Get digest for "; fi
         tmpfile=$(mktemp)
         echo ${image} | sed -r \
             `# for plugin & devfile registries, use internal Brew versions` \
-            -e "s|registry.redhat.io/codeready-workspaces/(pluginregistry-rhel8:.+)|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-\\1|g" \
-            -e "s|registry.redhat.io/codeready-workspaces/(devfileregistry-rhel8:.+)|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-\\1|g" \
+            -e "s|registry.redhat.io/codeready-workspaces/(pluginregistry-rhel8:.+)|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-\1|g" \
+            -e "s|registry.redhat.io/codeready-workspaces/(devfileregistry-rhel8:.+)|registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-\1|g" \
             `# in all other cases (including operator) use published quay images to compute digests` \
             -e "s|registry.redhat.io/codeready-workspaces/(.+)|quay.io/crw/\\1|g" \
             > ${tmpfile}
         alt_image=$(cat ${tmpfile})
         rm -f ${tmpfile}
-        if [[ ! "${QUIET}" ]]; then echo "${alt_image}"; fi
-
-        digest="$(skopeo inspect --tls-verify=false docker://${alt_image} | jq -r '.Digest')"
-        if [[ ! "${QUIET}" ]]; then echo -n "[INFO] Got digest"; fi
-        echo "    $digest # ${alt_image}"
-        if [[ ! ${digest} ]]; then
-          echo "[ERROR] Could not retrieve digest for '${image}' or '${alt_image}': fail!"; exit 1
+        if [[ ! "${QUIET}" ]]; then 
+          if [[ "${alt_image}" != "${image}" ]]; then echo "${alt_image} (${image})"; else echo "${alt_image}"; fi
         fi
+        ARCH_OVERRIDE="" # optional override so that an image without amd64 won't return a failure when searching on amd64 arch machines
+        if [[ ${image} == *"-openj9"* ]]; then
+          ARCH_OVERRIDE="--override-arch s390x"
+        fi
+        digest="$(skopeo ${ARCH_OVERRIDE} inspect --tls-verify=false docker://${alt_image} 2>/dev/null | jq -r '.Digest')"

--- a/controller-manifests/v2.4.0/codeready-workspaces.csv.yaml
+++ b/controller-manifests/v2.4.0/codeready-workspaces.csv.yaml
@@ -49,8 +49,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools, OpenShift Optional
     certified: "true"
-    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:2.4
-    createdAt: "2020-08-27T16:57:38+00:00"
+    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:44a44cf515078008184c8ec92760eebaf32e6005966368c1cba8e7b2bf64a59f
+    createdAt: "2020-09-15T21:13:41+00:00"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: openshift-workspaces
@@ -270,105 +270,105 @@ spec:
                   - command:
                       - /usr/local/bin/che-operator
                     env:
-                      - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.annotations['olm.targetNamespaces']
-                      - name: POD_NAME
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.name
-                      - name: OPERATOR_NAME
-                        value: codeready-operator
-                      - name: CHE_VERSION
-                        value: 2.4.0
-                      - name: RELATED_IMAGE_che_server
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8:2.4
-                      - name: RELATED_IMAGE_plugin_registry
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8:2.4
-                      - name: RELATED_IMAGE_devfile_registry
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8:2.4
-                      - name: RELATED_IMAGE_pvc_jobs
-                        value: registry.redhat.io/ubi8-minimal:8.2
-                      - name: RELATED_IMAGE_postgres
-                        value: registry.redhat.io/rhel8/postgresql-96:1
-                      - name: RELATED_IMAGE_keycloak
-                        value: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
-                      - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8:2.4
-                      - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8:2.4
-                      - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8:2.4
                       - name: CHE_FLAVOR
                         value: codeready
-                      - name: CONSOLE_LINK_NAME
-                        value: che
-                      - name: CONSOLE_LINK_DISPLAY_NAME
-                        value: CodeReady Workspaces
-                      - name: CONSOLE_LINK_SECTION
-                        value: Red Hat Applications
-                      - name: CONSOLE_LINK_IMAGE
-                        value: /dashboard/assets/branding/loader.svg
-                      - name: CHE_IDENTITY_SECRET
-                        value: che-identity-secret
                       - name: CHE_IDENTITY_POSTGRES_SECRET
                         value: che-identity-postgres-secret
+                      - name: CHE_IDENTITY_SECRET
+                        value: che-identity-secret
                       - name: CHE_POSTGRES_SECRET
                         value: che-postgres-secret
                       - name: CHE_SERVER_TRUST_STORE_CONFIGMAP_NAME
                         value: ca-certs
-                      - name: RELATED_IMAGE_keycloak_ppc64le
-                        value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
-                      - name: RELATED_IMAGE_keycloak_s390x
-                        value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
+                      - name: CHE_VERSION
+                        value: 2.4.0
+                      - name: CONSOLE_LINK_DISPLAY_NAME
+                        value: CodeReady Workspaces
+                      - name: CONSOLE_LINK_IMAGE
+                        value: /dashboard/assets/branding/loader.svg
+                      - name: CONSOLE_LINK_NAME
+                        value: che
+                      - name: CONSOLE_LINK_SECTION
+                        value: Red Hat Applications
+                      - name: OPERATOR_NAME
+                        value: codeready-operator
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: RELATED_IMAGE_che_server
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8@sha256:e0d9eec0ece81aaa13ad7c46cb05c7bf3b6200d0d191c04d4dbd317377430892
+                      - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8@sha256:5b738739554bbec9c1193230e5c18d923a30f9c8a06bc7d10a8d6b3690f453ea
+                      - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8@sha256:8a73b1c45f17855c57dd03b2099e6ea936f6bdf0a949c58bc528be496f6aa903
+                      - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8@sha256:fb92b6186e358f9b1f1f1f49406ae4dac30e72a47e7ec1b105dd9861c9ae6582
                       - name: RELATED_IMAGE_codeready_workspaces_machineexec
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_openj9
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_s390x
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_ppc64le
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8@sha256:ceb4dc67ecac9c9590447e9d6698e327e4db22d6c3d49312920922275e1384ce
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java11
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_openj9
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_s390x
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_ppc64le
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8@sha256:9ca5d40fa5332101b822847fcf18ff0ccba12b7ce059be9b8a9282b41074a261
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_openj9
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:230aa669d436e0ded71d003f57429e006ffc6ad3cd77384e97173fb3c73b89ef
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_ppc64le
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:230aa669d436e0ded71d003f57429e006ffc6ad3cd77384e97173fb3c73b89ef
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_s390x
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:230aa669d436e0ded71d003f57429e006ffc6ad3cd77384e97173fb3c73b89ef
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java8
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8@sha256:028014ddf39ac3d84fd9f1ffb3e2ad9de55116b850a358ba8ac6441ce988fda2
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_openj9
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:5954d997a49f167c5247d1091d3921e2b0284686b789e268f0b06f37f8e3f021
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_ppc64le
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:5954d997a49f167c5247d1091d3921e2b0284686b789e268f0b06f37f8e3f021
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_s390x
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:5954d997a49f167c5247d1091d3921e2b0284686b789e268f0b06f37f8e3f021
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_kubernetes
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8@sha256:767927486e91217e9ce6613516779689d9b12a80f80bb9a7dd18292a2ea6ddef
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_openshift
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8@sha256:9abac36f76e9c2ab445391ab5050dcaae4e2c283c5b1a64843607b805742c917
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_cpp
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8@sha256:74946020787106f39f647e29f1a1c79d00edbef46f81b6da4d663881d2013d32
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_dotnet
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8@sha256:9e32ca87441fc5bc01b40a8f27b8306e17fbff8326f66fcbbaf75584483bc078
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_golang
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8@sha256:59613fea7f436434b8c7a1f786c49b92062c375c3145a6be2e20d760ab8592aa
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_php
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_theia_endpoint
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8@sha256:f6e5aead1c54c46f146e6ae989a37bc3a5ec01d85b9a419b1eb0fa8b0d1bff53
                       - name: RELATED_IMAGE_codeready_workspaces_theia
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8@sha256:2b5ae8aad65a1bccac98683fb32918a7015fe28bdddc20771417e8c83db8ebb0
+                      - name: RELATED_IMAGE_codeready_workspaces_theia_endpoint
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8@sha256:d076c370bf0c7089adc0007f8cafb8166d65f6880430e79abbebe6b54fd3649a
+                      - name: RELATED_IMAGE_devfile_registry
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8@sha256:da18ae4db9ddfafb719c9ecaaaa66f5e50924067eae4b66a9a45a2c59f0f227a
                       - name: RELATED_IMAGE_jboss_eap_7_eap73_openjdk8_openshift_rhel7
-                        value: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.1
+                        value: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7@sha256:24dea0cfc154a23c1aeb6b46ade182d0f981362f36b7e6fb9c7d8531ac639fe0
                       - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openj9_11_openshift
-                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8:1.0
-                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openjdk11_openshift_s390x
-                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8:1.0
-                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openjdk11_openshift_ppc64le
-                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8:1.0
+                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8@sha256:d6a7bdbf4726fe0e0e54c0bce9b2257bbd2a165c37cb4ec68e1f994716ffb15c
                       - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openjdk11_openshift
-                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0-3
+                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8@sha256:94e1cd4eb4196a358e301c1992663258c0016c80247f507fd1c39cf9a73da833
+                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openjdk11_openshift_ppc64le
+                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8@sha256:d6a7bdbf4726fe0e0e54c0bce9b2257bbd2a165c37cb4ec68e1f994716ffb15c
+                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openjdk11_openshift_s390x
+                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8@sha256:d6a7bdbf4726fe0e0e54c0bce9b2257bbd2a165c37cb4ec68e1f994716ffb15c
+                      - name: RELATED_IMAGE_keycloak
+                        value: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:ec6801343eb1ca085154d8d7481552f2e9debc414125413d25e42216aa5922af
+                      - name: RELATED_IMAGE_keycloak_ppc64le
+                        value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
+                      - name: RELATED_IMAGE_keycloak_s390x
+                        value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
+                      - name: RELATED_IMAGE_plugin_registry
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8@sha256:d64262adf1de376eb72f1aa7be8ee796af2406e2279fbca5afa432b97f9c0f87
+                      - name: RELATED_IMAGE_postgres
+                        value: registry.redhat.io/rhel8/postgresql-96@sha256:fdc2398a25530547354714f2538c691d91b700e0cedef5361a3e7d96ddfd4e11
+                      - name: RELATED_IMAGE_pvc_jobs
+                        value: registry.redhat.io/ubi8-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
                       - name: RELATED_IMAGE_rhscl_mongodb_36_rhel7
-                        value: registry.redhat.io/rhscl/mongodb-36-rhel7:1-50
-                    image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:2.4
+                        value: registry.redhat.io/rhscl/mongodb-36-rhel7@sha256:9f799d356d7d2e442bde9d401b720600fd9059a3d8eefea6f3b2ffa721c0dc73
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                    image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:44a44cf515078008184c8ec92760eebaf32e6005966368c1cba8e7b2bf64a59f
                     imagePullPolicy: Always
                     name: codeready-operator
                     ports:
@@ -485,3 +485,124 @@ spec:
     name: Red Hat
   replaces: crwoperator.v2.3.0
   version: 2.4.0
+  relatedImages:
+    - name: codeready-workspaces-operator
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:44a44cf515078008184c8ec92760eebaf32e6005966368c1cba8e7b2bf64a59f
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:2.4
+    - name: codeready-workspaces-server-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8@sha256:e0d9eec0ece81aaa13ad7c46cb05c7bf3b6200d0d191c04d4dbd317377430892
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8:2.4
+    - name: codeready-workspaces-jwtproxy-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8@sha256:5b738739554bbec9c1193230e5c18d923a30f9c8a06bc7d10a8d6b3690f453ea
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8:2.4
+    - name: codeready-workspaces-pluginbroker-artifacts-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8@sha256:8a73b1c45f17855c57dd03b2099e6ea936f6bdf0a949c58bc528be496f6aa903
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8:2.4
+    - name: codeready-workspaces-pluginbroker-metadata-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8@sha256:fb92b6186e358f9b1f1f1f49406ae4dac30e72a47e7ec1b105dd9861c9ae6582
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8:2.4
+    - name: codeready-workspaces-machineexec-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8@sha256:ceb4dc67ecac9c9590447e9d6698e327e4db22d6c3d49312920922275e1384ce
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8:2.4
+    - name: codeready-workspaces-plugin-java11-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8@sha256:9ca5d40fa5332101b822847fcf18ff0ccba12b7ce059be9b8a9282b41074a261
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8:2.4
+    - name: codeready-workspaces-plugin-java11-openj9-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:230aa669d436e0ded71d003f57429e006ffc6ad3cd77384e97173fb3c73b89ef
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.4
+    - name: codeready-workspaces-plugin-java8-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8@sha256:028014ddf39ac3d84fd9f1ffb3e2ad9de55116b850a358ba8ac6441ce988fda2
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8:2.4
+    - name: codeready-workspaces-plugin-java8-openj9-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:5954d997a49f167c5247d1091d3921e2b0284686b789e268f0b06f37f8e3f021
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.4
+    - name: codeready-workspaces-plugin-kubernetes-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8@sha256:767927486e91217e9ce6613516779689d9b12a80f80bb9a7dd18292a2ea6ddef
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8:2.4
+    - name: codeready-workspaces-plugin-openshift-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8@sha256:9abac36f76e9c2ab445391ab5050dcaae4e2c283c5b1a64843607b805742c917
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8:2.4
+    - name: codeready-workspaces-stacks-cpp-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8@sha256:74946020787106f39f647e29f1a1c79d00edbef46f81b6da4d663881d2013d32
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8:2.4
+    - name: codeready-workspaces-stacks-dotnet-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8@sha256:9e32ca87441fc5bc01b40a8f27b8306e17fbff8326f66fcbbaf75584483bc078
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8:2.4
+    - name: codeready-workspaces-stacks-golang-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8@sha256:59613fea7f436434b8c7a1f786c49b92062c375c3145a6be2e20d760ab8592aa
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8:2.4
+    - name: codeready-workspaces-stacks-php-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8@sha256:f6e5aead1c54c46f146e6ae989a37bc3a5ec01d85b9a419b1eb0fa8b0d1bff53
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8:2.4
+    - name: codeready-workspaces-theia-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8@sha256:2b5ae8aad65a1bccac98683fb32918a7015fe28bdddc20771417e8c83db8ebb0
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8:2.4
+    - name: codeready-workspaces-theia-endpoint-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8@sha256:d076c370bf0c7089adc0007f8cafb8166d65f6880430e79abbebe6b54fd3649a
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8:2.4
+    - name: codeready-workspaces-devfileregistry-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8@sha256:da18ae4db9ddfafb719c9ecaaaa66f5e50924067eae4b66a9a45a2c59f0f227a
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8:2.4
+    - name: eap73-openjdk8-openshift-rhel7
+      image: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7@sha256:24dea0cfc154a23c1aeb6b46ade182d0f981362f36b7e6fb9c7d8531ac639fe0
+      # tag: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.1
+    - name: eap-xp1-openj9-11-openshift-rhel8
+      image: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8@sha256:d6a7bdbf4726fe0e0e54c0bce9b2257bbd2a165c37cb4ec68e1f994716ffb15c
+      # tag: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8:1.0
+    - name: eap-xp1-openjdk11-openshift-rhel8
+      image: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8@sha256:94e1cd4eb4196a358e301c1992663258c0016c80247f507fd1c39cf9a73da833
+      # tag: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0-3
+    - name: sso74-openshift-rhel8
+      image: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:ec6801343eb1ca085154d8d7481552f2e9debc414125413d25e42216aa5922af
+      # tag: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
+    - name: sso74-openj9-openshift-rhel8
+      image: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
+      # tag: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
+    - name: codeready-workspaces-pluginregistry-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8@sha256:d64262adf1de376eb72f1aa7be8ee796af2406e2279fbca5afa432b97f9c0f87
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8:2.4
+    - name: postgresql-96
+      image: registry.redhat.io/rhel8/postgresql-96@sha256:fdc2398a25530547354714f2538c691d91b700e0cedef5361a3e7d96ddfd4e11
+      # tag: registry.redhat.io/rhel8/postgresql-96:1
+    - name: ubi8-minimal
+      image: registry.redhat.io/ubi8-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
+      # tag: registry.redhat.io/ubi8-minimal:8.2
+    - name: mongodb-36-rhel7
+      image: registry.redhat.io/rhscl/mongodb-36-rhel7@sha256:9f799d356d7d2e442bde9d401b720600fd9059a3d8eefea6f3b2ffa721c0dc73
+      # tag: registry.redhat.io/rhscl/mongodb-36-rhel7:1-50
+    - name: plugin-java11-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:9ca5d40fa5332101b822847fcf18ff0ccba12b7ce059be9b8a9282b41074a261
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:9ca5d40fa5332101b822847fcf18ff0ccba12b7ce059be9b8a9282b41074a261
+    - name: plugin-java8-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:028014ddf39ac3d84fd9f1ffb3e2ad9de55116b850a358ba8ac6441ce988fda2
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:028014ddf39ac3d84fd9f1ffb3e2ad9de55116b850a358ba8ac6441ce988fda2
+    - name: stacks-cpp-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:74946020787106f39f647e29f1a1c79d00edbef46f81b6da4d663881d2013d32
+      # tag: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:74946020787106f39f647e29f1a1c79d00edbef46f81b6da4d663881d2013d32
+    - name: stacks-dotnet-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:9e32ca87441fc5bc01b40a8f27b8306e17fbff8326f66fcbbaf75584483bc078
+      # tag: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:9e32ca87441fc5bc01b40a8f27b8306e17fbff8326f66fcbbaf75584483bc078
+    - name: stacks-golang-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:59613fea7f436434b8c7a1f786c49b92062c375c3145a6be2e20d760ab8592aa
+      # tag: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:59613fea7f436434b8c7a1f786c49b92062c375c3145a6be2e20d760ab8592aa
+    - name: stacks-php-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:f6e5aead1c54c46f146e6ae989a37bc3a5ec01d85b9a419b1eb0fa8b0d1bff53
+      # tag: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:f6e5aead1c54c46f146e6ae989a37bc3a5ec01d85b9a419b1eb0fa8b0d1bff53
+    - name: machineexec-rhel8
+      image: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:02689e6bf8b88138458243d2b6b264b9d41ea7259b7d3552020ff78b627c6679
+      # tag: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:02689e6bf8b88138458243d2b6b264b9d41ea7259b7d3552020ff78b627c6679
+    - name: plugin-kubernetes-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:686d407134b8815371e8b2fd82bb3aa5e55b177c9b7795a0e87b76657963cae8
+      # tag: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:686d407134b8815371e8b2fd82bb3aa5e55b177c9b7795a0e87b76657963cae8
+    - name: plugin-openshift-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9abac36f76e9c2ab445391ab5050dcaae4e2c283c5b1a64843607b805742c917
+      # tag: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9abac36f76e9c2ab445391ab5050dcaae4e2c283c5b1a64843607b805742c917
+    - name: stacks-java-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8@sha256:573ca673f972ba6a73d21da03cef927f753604d7a4e452f44ea6ee76d9d03394
+      # tag: registry.redhat.io/codeready-workspaces/stacks-java-rhel8@sha256:573ca673f972ba6a73d21da03cef927f753604d7a4e452f44ea6ee76d9d03394
+    - name: theia-endpoint-rhel8
+      image: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:38ef6428c882032f3109d35f9b9e235cffa5e5e4febf575da1eb1392a831e276
+      # tag: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:38ef6428c882032f3109d35f9b9e235cffa5e5e4febf575da1eb1392a831e276
+    - name: theia-rhel8
+      image: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:2b5ae8aad65a1bccac98683fb32918a7015fe28bdddc20771417e8c83db8ebb0
+      # tag: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:2b5ae8aad65a1bccac98683fb32918a7015fe28bdddc20771417e8c83db8ebb0

--- a/manifests/codeready-workspaces.csv.yaml
+++ b/manifests/codeready-workspaces.csv.yaml
@@ -49,8 +49,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools, OpenShift Optional
     certified: "true"
-    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:2.4
-    createdAt: "2020-08-27T16:57:38+00:00"
+    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:44a44cf515078008184c8ec92760eebaf32e6005966368c1cba8e7b2bf64a59f
+    createdAt: "2020-09-15T21:13:41+00:00"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: openshift-workspaces
@@ -270,105 +270,105 @@ spec:
                   - command:
                       - /usr/local/bin/che-operator
                     env:
-                      - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.annotations['olm.targetNamespaces']
-                      - name: POD_NAME
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.name
-                      - name: OPERATOR_NAME
-                        value: codeready-operator
-                      - name: CHE_VERSION
-                        value: 2.4.0
-                      - name: RELATED_IMAGE_che_server
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8:2.4
-                      - name: RELATED_IMAGE_plugin_registry
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8:2.4
-                      - name: RELATED_IMAGE_devfile_registry
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8:2.4
-                      - name: RELATED_IMAGE_pvc_jobs
-                        value: registry.redhat.io/ubi8-minimal:8.2
-                      - name: RELATED_IMAGE_postgres
-                        value: registry.redhat.io/rhel8/postgresql-96:1
-                      - name: RELATED_IMAGE_keycloak
-                        value: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
-                      - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8:2.4
-                      - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8:2.4
-                      - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8:2.4
                       - name: CHE_FLAVOR
                         value: codeready
-                      - name: CONSOLE_LINK_NAME
-                        value: che
-                      - name: CONSOLE_LINK_DISPLAY_NAME
-                        value: CodeReady Workspaces
-                      - name: CONSOLE_LINK_SECTION
-                        value: Red Hat Applications
-                      - name: CONSOLE_LINK_IMAGE
-                        value: /dashboard/assets/branding/loader.svg
-                      - name: CHE_IDENTITY_SECRET
-                        value: che-identity-secret
                       - name: CHE_IDENTITY_POSTGRES_SECRET
                         value: che-identity-postgres-secret
+                      - name: CHE_IDENTITY_SECRET
+                        value: che-identity-secret
                       - name: CHE_POSTGRES_SECRET
                         value: che-postgres-secret
                       - name: CHE_SERVER_TRUST_STORE_CONFIGMAP_NAME
                         value: ca-certs
-                      - name: RELATED_IMAGE_keycloak_ppc64le
-                        value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
-                      - name: RELATED_IMAGE_keycloak_s390x
-                        value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
+                      - name: CHE_VERSION
+                        value: 2.4.0
+                      - name: CONSOLE_LINK_DISPLAY_NAME
+                        value: CodeReady Workspaces
+                      - name: CONSOLE_LINK_IMAGE
+                        value: /dashboard/assets/branding/loader.svg
+                      - name: CONSOLE_LINK_NAME
+                        value: che
+                      - name: CONSOLE_LINK_SECTION
+                        value: Red Hat Applications
+                      - name: OPERATOR_NAME
+                        value: codeready-operator
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: RELATED_IMAGE_che_server
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8@sha256:e0d9eec0ece81aaa13ad7c46cb05c7bf3b6200d0d191c04d4dbd317377430892
+                      - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8@sha256:5b738739554bbec9c1193230e5c18d923a30f9c8a06bc7d10a8d6b3690f453ea
+                      - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8@sha256:8a73b1c45f17855c57dd03b2099e6ea936f6bdf0a949c58bc528be496f6aa903
+                      - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8@sha256:fb92b6186e358f9b1f1f1f49406ae4dac30e72a47e7ec1b105dd9861c9ae6582
                       - name: RELATED_IMAGE_codeready_workspaces_machineexec
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_openj9
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_s390x
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_ppc64le
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8@sha256:ceb4dc67ecac9c9590447e9d6698e327e4db22d6c3d49312920922275e1384ce
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java11
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_openj9
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_s390x
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_ppc64le
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8@sha256:9ca5d40fa5332101b822847fcf18ff0ccba12b7ce059be9b8a9282b41074a261
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_openj9
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:230aa669d436e0ded71d003f57429e006ffc6ad3cd77384e97173fb3c73b89ef
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_ppc64le
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:230aa669d436e0ded71d003f57429e006ffc6ad3cd77384e97173fb3c73b89ef
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_s390x
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:230aa669d436e0ded71d003f57429e006ffc6ad3cd77384e97173fb3c73b89ef
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java8
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8@sha256:028014ddf39ac3d84fd9f1ffb3e2ad9de55116b850a358ba8ac6441ce988fda2
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_openj9
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:5954d997a49f167c5247d1091d3921e2b0284686b789e268f0b06f37f8e3f021
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_ppc64le
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:5954d997a49f167c5247d1091d3921e2b0284686b789e268f0b06f37f8e3f021
+                      - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_s390x
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:5954d997a49f167c5247d1091d3921e2b0284686b789e268f0b06f37f8e3f021
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_kubernetes
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8@sha256:767927486e91217e9ce6613516779689d9b12a80f80bb9a7dd18292a2ea6ddef
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_openshift
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8@sha256:9abac36f76e9c2ab445391ab5050dcaae4e2c283c5b1a64843607b805742c917
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_cpp
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8@sha256:74946020787106f39f647e29f1a1c79d00edbef46f81b6da4d663881d2013d32
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_dotnet
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8@sha256:9e32ca87441fc5bc01b40a8f27b8306e17fbff8326f66fcbbaf75584483bc078
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_golang
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8@sha256:59613fea7f436434b8c7a1f786c49b92062c375c3145a6be2e20d760ab8592aa
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_php
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8:2.4
-                      - name: RELATED_IMAGE_codeready_workspaces_theia_endpoint
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8@sha256:f6e5aead1c54c46f146e6ae989a37bc3a5ec01d85b9a419b1eb0fa8b0d1bff53
                       - name: RELATED_IMAGE_codeready_workspaces_theia
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8:2.4
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8@sha256:2b5ae8aad65a1bccac98683fb32918a7015fe28bdddc20771417e8c83db8ebb0
+                      - name: RELATED_IMAGE_codeready_workspaces_theia_endpoint
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8@sha256:d076c370bf0c7089adc0007f8cafb8166d65f6880430e79abbebe6b54fd3649a
+                      - name: RELATED_IMAGE_devfile_registry
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8@sha256:da18ae4db9ddfafb719c9ecaaaa66f5e50924067eae4b66a9a45a2c59f0f227a
                       - name: RELATED_IMAGE_jboss_eap_7_eap73_openjdk8_openshift_rhel7
-                        value: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.1
+                        value: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7@sha256:24dea0cfc154a23c1aeb6b46ade182d0f981362f36b7e6fb9c7d8531ac639fe0
                       - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openj9_11_openshift
-                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8:1.0
-                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openjdk11_openshift_s390x
-                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8:1.0
-                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openjdk11_openshift_ppc64le
-                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8:1.0
+                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8@sha256:d6a7bdbf4726fe0e0e54c0bce9b2257bbd2a165c37cb4ec68e1f994716ffb15c
                       - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openjdk11_openshift
-                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0-3
+                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8@sha256:94e1cd4eb4196a358e301c1992663258c0016c80247f507fd1c39cf9a73da833
+                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openjdk11_openshift_ppc64le
+                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8@sha256:d6a7bdbf4726fe0e0e54c0bce9b2257bbd2a165c37cb4ec68e1f994716ffb15c
+                      - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openjdk11_openshift_s390x
+                        value: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8@sha256:d6a7bdbf4726fe0e0e54c0bce9b2257bbd2a165c37cb4ec68e1f994716ffb15c
+                      - name: RELATED_IMAGE_keycloak
+                        value: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:ec6801343eb1ca085154d8d7481552f2e9debc414125413d25e42216aa5922af
+                      - name: RELATED_IMAGE_keycloak_ppc64le
+                        value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
+                      - name: RELATED_IMAGE_keycloak_s390x
+                        value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
+                      - name: RELATED_IMAGE_plugin_registry
+                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8@sha256:d64262adf1de376eb72f1aa7be8ee796af2406e2279fbca5afa432b97f9c0f87
+                      - name: RELATED_IMAGE_postgres
+                        value: registry.redhat.io/rhel8/postgresql-96@sha256:fdc2398a25530547354714f2538c691d91b700e0cedef5361a3e7d96ddfd4e11
+                      - name: RELATED_IMAGE_pvc_jobs
+                        value: registry.redhat.io/ubi8-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
                       - name: RELATED_IMAGE_rhscl_mongodb_36_rhel7
-                        value: registry.redhat.io/rhscl/mongodb-36-rhel7:1-50
-                    image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:2.4
+                        value: registry.redhat.io/rhscl/mongodb-36-rhel7@sha256:9f799d356d7d2e442bde9d401b720600fd9059a3d8eefea6f3b2ffa721c0dc73
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                    image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:44a44cf515078008184c8ec92760eebaf32e6005966368c1cba8e7b2bf64a59f
                     imagePullPolicy: Always
                     name: codeready-operator
                     ports:
@@ -485,3 +485,124 @@ spec:
     name: Red Hat
   replaces: crwoperator.v2.3.0
   version: 2.4.0
+  relatedImages:
+    - name: codeready-workspaces-operator
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:44a44cf515078008184c8ec92760eebaf32e6005966368c1cba8e7b2bf64a59f
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:2.4
+    - name: codeready-workspaces-server-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8@sha256:e0d9eec0ece81aaa13ad7c46cb05c7bf3b6200d0d191c04d4dbd317377430892
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8:2.4
+    - name: codeready-workspaces-jwtproxy-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8@sha256:5b738739554bbec9c1193230e5c18d923a30f9c8a06bc7d10a8d6b3690f453ea
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8:2.4
+    - name: codeready-workspaces-pluginbroker-artifacts-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8@sha256:8a73b1c45f17855c57dd03b2099e6ea936f6bdf0a949c58bc528be496f6aa903
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8:2.4
+    - name: codeready-workspaces-pluginbroker-metadata-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8@sha256:fb92b6186e358f9b1f1f1f49406ae4dac30e72a47e7ec1b105dd9861c9ae6582
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8:2.4
+    - name: codeready-workspaces-machineexec-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8@sha256:ceb4dc67ecac9c9590447e9d6698e327e4db22d6c3d49312920922275e1384ce
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8:2.4
+    - name: codeready-workspaces-plugin-java11-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8@sha256:9ca5d40fa5332101b822847fcf18ff0ccba12b7ce059be9b8a9282b41074a261
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8:2.4
+    - name: codeready-workspaces-plugin-java11-openj9-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:230aa669d436e0ded71d003f57429e006ffc6ad3cd77384e97173fb3c73b89ef
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.4
+    - name: codeready-workspaces-plugin-java8-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8@sha256:028014ddf39ac3d84fd9f1ffb3e2ad9de55116b850a358ba8ac6441ce988fda2
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8:2.4
+    - name: codeready-workspaces-plugin-java8-openj9-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:5954d997a49f167c5247d1091d3921e2b0284686b789e268f0b06f37f8e3f021
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.4
+    - name: codeready-workspaces-plugin-kubernetes-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8@sha256:767927486e91217e9ce6613516779689d9b12a80f80bb9a7dd18292a2ea6ddef
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8:2.4
+    - name: codeready-workspaces-plugin-openshift-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8@sha256:9abac36f76e9c2ab445391ab5050dcaae4e2c283c5b1a64843607b805742c917
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8:2.4
+    - name: codeready-workspaces-stacks-cpp-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8@sha256:74946020787106f39f647e29f1a1c79d00edbef46f81b6da4d663881d2013d32
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8:2.4
+    - name: codeready-workspaces-stacks-dotnet-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8@sha256:9e32ca87441fc5bc01b40a8f27b8306e17fbff8326f66fcbbaf75584483bc078
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8:2.4
+    - name: codeready-workspaces-stacks-golang-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8@sha256:59613fea7f436434b8c7a1f786c49b92062c375c3145a6be2e20d760ab8592aa
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8:2.4
+    - name: codeready-workspaces-stacks-php-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8@sha256:f6e5aead1c54c46f146e6ae989a37bc3a5ec01d85b9a419b1eb0fa8b0d1bff53
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8:2.4
+    - name: codeready-workspaces-theia-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8@sha256:2b5ae8aad65a1bccac98683fb32918a7015fe28bdddc20771417e8c83db8ebb0
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8:2.4
+    - name: codeready-workspaces-theia-endpoint-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8@sha256:d076c370bf0c7089adc0007f8cafb8166d65f6880430e79abbebe6b54fd3649a
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8:2.4
+    - name: codeready-workspaces-devfileregistry-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8@sha256:da18ae4db9ddfafb719c9ecaaaa66f5e50924067eae4b66a9a45a2c59f0f227a
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8:2.4
+    - name: eap73-openjdk8-openshift-rhel7
+      image: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7@sha256:24dea0cfc154a23c1aeb6b46ade182d0f981362f36b7e6fb9c7d8531ac639fe0
+      # tag: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.1
+    - name: eap-xp1-openj9-11-openshift-rhel8
+      image: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8@sha256:d6a7bdbf4726fe0e0e54c0bce9b2257bbd2a165c37cb4ec68e1f994716ffb15c
+      # tag: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8:1.0
+    - name: eap-xp1-openjdk11-openshift-rhel8
+      image: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8@sha256:94e1cd4eb4196a358e301c1992663258c0016c80247f507fd1c39cf9a73da833
+      # tag: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0-3
+    - name: sso74-openshift-rhel8
+      image: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:ec6801343eb1ca085154d8d7481552f2e9debc414125413d25e42216aa5922af
+      # tag: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
+    - name: sso74-openj9-openshift-rhel8
+      image: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
+      # tag: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
+    - name: codeready-workspaces-pluginregistry-rhel8
+      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8@sha256:d64262adf1de376eb72f1aa7be8ee796af2406e2279fbca5afa432b97f9c0f87
+      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8:2.4
+    - name: postgresql-96
+      image: registry.redhat.io/rhel8/postgresql-96@sha256:fdc2398a25530547354714f2538c691d91b700e0cedef5361a3e7d96ddfd4e11
+      # tag: registry.redhat.io/rhel8/postgresql-96:1
+    - name: ubi8-minimal
+      image: registry.redhat.io/ubi8-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
+      # tag: registry.redhat.io/ubi8-minimal:8.2
+    - name: mongodb-36-rhel7
+      image: registry.redhat.io/rhscl/mongodb-36-rhel7@sha256:9f799d356d7d2e442bde9d401b720600fd9059a3d8eefea6f3b2ffa721c0dc73
+      # tag: registry.redhat.io/rhscl/mongodb-36-rhel7:1-50
+    - name: plugin-java11-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:9ca5d40fa5332101b822847fcf18ff0ccba12b7ce059be9b8a9282b41074a261
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:9ca5d40fa5332101b822847fcf18ff0ccba12b7ce059be9b8a9282b41074a261
+    - name: plugin-java8-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:028014ddf39ac3d84fd9f1ffb3e2ad9de55116b850a358ba8ac6441ce988fda2
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:028014ddf39ac3d84fd9f1ffb3e2ad9de55116b850a358ba8ac6441ce988fda2
+    - name: stacks-cpp-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:74946020787106f39f647e29f1a1c79d00edbef46f81b6da4d663881d2013d32
+      # tag: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:74946020787106f39f647e29f1a1c79d00edbef46f81b6da4d663881d2013d32
+    - name: stacks-dotnet-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:9e32ca87441fc5bc01b40a8f27b8306e17fbff8326f66fcbbaf75584483bc078
+      # tag: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:9e32ca87441fc5bc01b40a8f27b8306e17fbff8326f66fcbbaf75584483bc078
+    - name: stacks-golang-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:59613fea7f436434b8c7a1f786c49b92062c375c3145a6be2e20d760ab8592aa
+      # tag: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:59613fea7f436434b8c7a1f786c49b92062c375c3145a6be2e20d760ab8592aa
+    - name: stacks-php-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:f6e5aead1c54c46f146e6ae989a37bc3a5ec01d85b9a419b1eb0fa8b0d1bff53
+      # tag: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:f6e5aead1c54c46f146e6ae989a37bc3a5ec01d85b9a419b1eb0fa8b0d1bff53
+    - name: machineexec-rhel8
+      image: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:02689e6bf8b88138458243d2b6b264b9d41ea7259b7d3552020ff78b627c6679
+      # tag: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:02689e6bf8b88138458243d2b6b264b9d41ea7259b7d3552020ff78b627c6679
+    - name: plugin-kubernetes-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:686d407134b8815371e8b2fd82bb3aa5e55b177c9b7795a0e87b76657963cae8
+      # tag: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:686d407134b8815371e8b2fd82bb3aa5e55b177c9b7795a0e87b76657963cae8
+    - name: plugin-openshift-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9abac36f76e9c2ab445391ab5050dcaae4e2c283c5b1a64843607b805742c917
+      # tag: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9abac36f76e9c2ab445391ab5050dcaae4e2c283c5b1a64843607b805742c917
+    - name: stacks-java-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8@sha256:573ca673f972ba6a73d21da03cef927f753604d7a4e452f44ea6ee76d9d03394
+      # tag: registry.redhat.io/codeready-workspaces/stacks-java-rhel8@sha256:573ca673f972ba6a73d21da03cef927f753604d7a4e452f44ea6ee76d9d03394
+    - name: theia-endpoint-rhel8
+      image: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:38ef6428c882032f3109d35f9b9e235cffa5e5e4febf575da1eb1392a831e276
+      # tag: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:38ef6428c882032f3109d35f9b9e235cffa5e5e4febf575da1eb1392a831e276
+    - name: theia-rhel8
+      image: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:2b5ae8aad65a1bccac98683fb32918a7015fe28bdddc20771417e8c83db8ebb0
+      # tag: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:2b5ae8aad65a1bccac98683fb32918a7015fe28bdddc20771417e8c83db8ebb0

--- a/operator-metadata.Jenkinsfile
+++ b/operator-metadata.Jenkinsfile
@@ -36,9 +36,9 @@ sh '''#!/bin/bash -xe
 pushd /tmp >/dev/null
 # remove any older versions
 sudo yum remove -y skopeo || true
-# install from @kcrane's build
+# install from @kcrane build
 if [[ ! -x /usr/local/bin/skopeo ]]; then
-    sudo curl -sSLO https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/crw-deprecated_''' + CRW_VERSION + '''/lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/skopeo/target/skopeo-$(uname -m).tar.gz
+    sudo curl -sSLO "https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/crw-deprecated_''' + CRW_VERSION + '''/lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/skopeo/target/skopeo-$(uname -m).tar.gz"
 fi
 if [[ -f /tmp/skopeo-$(uname -m).tar.gz ]]; then 
     sudo tar xzf /tmp/skopeo-$(uname -m).tar.gz --overwrite -C /usr/local/bin/

--- a/operator-metadata.Jenkinsfile
+++ b/operator-metadata.Jenkinsfile
@@ -6,12 +6,14 @@
 // SOURCE_BRANCH = "7.16.x" or "master" // branch of source repo from which to find and sync commits to pkgs.devel repo
 // FORCE_BUILD = "false"
 
+import groovy.transform.Field
+
 def SOURCE_REPO = "eclipse/che-operator" //source repo from which to find and sync commits to pkgs.devel repo
 
 def MIDSTM_REPO = "redhat-developer/codeready-workspaces-operator" //source repo from which to find and sync commits to pkgs.devel repo
 def DWNSTM_REPO = "containers/codeready-workspaces-operator-metadata" // dist-git repo to use as target
 
-def MIDSTM_BRANCH = "crw-2.4-rhel-8" // target branch in GH repo, eg., crw-2.4-rhel-8
+@Field String MIDSTM_BRANCH = "crw-2.4-rhel-8" // target branch in GH repo, eg., crw-2.4-rhel-8
 def DWNSTM_BRANCH = "crw-2.4-rhel-8" // target branch in dist-git repo, eg., crw-2.4-rhel-8
 def SCRATCH = "false"
 def PUSH_TO_QUAY = "true"
@@ -19,10 +21,42 @@ def QUAY_PROJECT = "operator-metadata" // also used for the Brew dockerfile para
 
 def OLD_SHA_DWN=""
 
+@Field String CRW_VERSION_F = ""
+def String getCrwVersion(String MIDSTM_BRANCH) {
+  if (CRW_VERSION_F.equals("")) {
+    CRW_VERSION_F = sh(script: '''#!/bin/bash -xe
+    curl -sSLo- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + MIDSTM_BRANCH + '''/dependencies/VERSION''', returnStdout: true).trim()
+  }
+  return CRW_VERSION_F
+}
+
+def installSkopeo(String CRW_VERSION)
+{
+sh '''#!/bin/bash -xe
+pushd /tmp >/dev/null
+# remove any older versions
+sudo yum remove -y skopeo || true
+# install from @kcrane's build
+if [[ ! -x /usr/local/bin/skopeo ]]; then
+    sudo curl -sSLO https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/crw-deprecated_''' + CRW_VERSION + '''/lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/skopeo/target/skopeo-$(uname -m).tar.gz
+fi
+if [[ -f /tmp/skopeo-$(uname -m).tar.gz ]]; then 
+    sudo tar xzf /tmp/skopeo-$(uname -m).tar.gz --overwrite -C /usr/local/bin/
+    sudo chmod 755 /usr/local/bin/skopeo
+    sudo rm -f /tmp/skopeo-$(uname -m).tar.gz
+fi
+popd >/dev/null
+skopeo --version
+'''
+}
+
 def buildNode = "rhel7-releng" // slave label
 timeout(120) {
 	node("${buildNode}"){ stage "Sync repos"
-    cleanWs()
+      cleanWs()
+      CRW_VERSION = getCrwVersion(MIDSTM_BRANCH)
+      println "CRW_VERSION = '" + CRW_VERSION + "'"
+      installSkopeo(CRW_VERSION)
       withCredentials([string(credentialsId:'devstudio-release.token', variable: 'GITHUB_TOKEN'), 
         file(credentialsId: 'crw-build.keytab', variable: 'CRW_KEYTAB')]) {
           checkout([$class: 'GitSCM',
@@ -191,7 +225,7 @@ done
 
 cp -f ${SOURCEDOCKERFILE} ${WORKSPACE}/targetdwn/Dockerfile
 
-CRW_VERSION=`wget -qO- https://raw.githubusercontent.com/redhat-developer/codeready-workspaces/''' + MIDSTM_BRANCH + '''/dependencies/VERSION`
+CRW_VERSION="''' + CRW_VERSION_F + '''"
 #apply patches
 sed -i ${WORKSPACE}/targetdwn/Dockerfile \
   -e "s#FROM registry.redhat.io/#FROM #g" \

--- a/operator.Jenkinsfile
+++ b/operator.Jenkinsfile
@@ -35,9 +35,9 @@ sh '''#!/bin/bash -xe
 pushd /tmp >/dev/null
 # remove any older versions
 sudo yum remove -y skopeo || true
-# install from @kcrane's build
+# install from @kcrane build
 if [[ ! -x /usr/local/bin/skopeo ]]; then
-    sudo curl -sSLO https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/crw-deprecated_''' + CRW_VERSION + '''/lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/skopeo/target/skopeo-$(uname -m).tar.gz
+    sudo curl -sSLO "https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/crw-deprecated_''' + CRW_VERSION + '''/lastSuccessfulBuild/artifact/codeready-workspaces-deprecated/skopeo/target/skopeo-$(uname -m).tar.gz"
 fi
 if [[ -f /tmp/skopeo-$(uname -m).tar.gz ]]; then 
     sudo tar xzf /tmp/skopeo-$(uname -m).tar.gz --overwrite -C /usr/local/bin/


### PR DESCRIPTION
re-enable addDigests.sh script;
sort RELATED_IMAGE_* env vars;
clean up console output a little;
make sure skopeo 1.1 is installed, as we need it for the arch override (to get digests for j9 images)

Change-Id: I31ba368c378c186584eb5d49a3b892d69d08e7b2
Signed-off-by: nickboldt <nboldt@redhat.com>