### PR TITLE
CRW-1233 remove duplicate/redundant/old related images

### DIFF
--- a/build/scripts/addDigests.sh
+++ b/build/scripts/addDigests.sh
@@ -55,10 +55,10 @@ mkdir -p ${BASE_DIR}/generated/${CSV_NAME}/
 cp -R ${BASE_DIR}/${SRC_DIR}/* ${BASE_DIR}/generated/${CSV_NAME}/
 
 # TODO: CRW-1044 support OCP 4.5 format until we switch to OCP 4.6
-if [[ -d $(find ${BASE_DIR}/generated/${CSV_NAME}/v${VERSION}/ || true) ]]; then
+if [[ -d ${BASE_DIR}/generated/${CSV_NAME}/v${VERSION} ]]; then
   CSV_FILE="$(find ${BASE_DIR}/generated/${CSV_NAME}/v${VERSION}/ -name "${CSV_NAME}.*${VERSION}.clusterserviceversion.yaml" -o -name "${CSV_NAME}.csv.yaml" | tail -1)"
 fi
-if [[ ! $CSV_FILE ]]; then 
+if [[ -z "${CSV_FILE}" ]]; then
   CSV_FILE="$(find ${BASE_DIR}/generated/${CSV_NAME}/ -name "${CSV_NAME}.csv.yaml" | tail -1)"
 fi
 if [[ ! ${CSV_FILE} ]]; then echo "[ERROR] ${0##*/} :: Could not find CSV to generate in ${BASE_DIR}/generated/${CSV_NAME}/ !"; exit 1; fi

--- a/build/scripts/addDigests.sh
+++ b/build/scripts/addDigests.sh
@@ -16,18 +16,18 @@ QUIET=""
 
 PODMAN=$(command -v podman)
 if [[ ! -x $PODMAN ]]; then
-  echo "[WARNING] podman is not installed."
+  echo "[WARNING] ${0##*/} :: podman is not installed."
   PODMAN=$(command -v docker)
   if [[ ! -x $PODMAN ]]; then
-    echo "[ERROR] docker is not installed. Aborting."; exit 1
+    echo "[ERROR] ${0##*/} :: docker is not installed. Aborting."; exit 1
   fi
 fi
 command -v yq >/dev/null 2>&1 || { echo "yq is not installed. Aborting."; exit 1; }
 
 usage () {
-	echo "Usage:   $0 [-w WORKDIR] -s [SOURCE_PATH] -n [csv name] -v [VERSION] -t [TAG]"
-	echo "Example: $0 -w $(pwd) -s eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift -n eclipse-che-preview-openshift -v 7.9.0"
-	echo "Example: $0 -w $(pwd) -s controller-manifests -n codeready-workspaces -v 2.y.0 -t 2.y"
+	echo "Usage:   ${0##*/} [-w WORKDIR] -s [SOURCE_PATH] -n [csv name] -v [VERSION] -t [TAG]"
+	echo "Example: ${0##*/} -w $(pwd) -s eclipse-che-preview-openshift/deploy/olm-catalog/eclipse-che-preview-openshift -n eclipse-che-preview-openshift -v 7.9.0"
+	echo "Example: ${0##*/} -w $(pwd) -s controller-manifests -n codeready-workspaces -v 2.y.0 -t 2.y"
 }
 
 if [[ $# -lt 1 ]]; then usage; exit; fi
@@ -54,10 +54,15 @@ rm -Rf ${BASE_DIR}/generated/${CSV_NAME}/
 mkdir -p ${BASE_DIR}/generated/${CSV_NAME}/
 cp -R ${BASE_DIR}/${SRC_DIR}/* ${BASE_DIR}/generated/${CSV_NAME}/
 
-# CSV_FILE="$(find ${BASE_DIR}/generated/${CSV_NAME}/*${VERSION}/ -name "${CSV_NAME}.*${VERSION}.clusterserviceversion.yaml" -o -name "${CSV_NAME}.csv.yaml" | tail -1)"
-CSV_FILE="$(find ${BASE_DIR}/generated/${CSV_NAME}/ -name "${CSV_NAME}.csv.yaml" | tail -1)"
-if [[ ! ${CSV_FILE} ]]; then echo "[ERROR] Could not find CSV to generate in ${BASE_DIR}/generated/${CSV_NAME}/ !"; exit 1; fi
-echo "[INFO] CSV to generate: ${CSV_FILE}"
+# TODO: CRW-1044 support OCP 4.5 format until we switch to OCP 4.6
+if [[ -d $(find ${BASE_DIR}/generated/${CSV_NAME}/v${VERSION}/ || true) ]]; then
+  CSV_FILE="$(find ${BASE_DIR}/generated/${CSV_NAME}/v${VERSION}/ -name "${CSV_NAME}.*${VERSION}.clusterserviceversion.yaml" -o -name "${CSV_NAME}.csv.yaml" | tail -1)"
+fi
+if [[ ! $CSV_FILE ]]; then 
+  CSV_FILE="$(find ${BASE_DIR}/generated/${CSV_NAME}/ -name "${CSV_NAME}.csv.yaml" | tail -1)"
+fi
+if [[ ! ${CSV_FILE} ]]; then echo "[ERROR] ${0##*/} :: Could not find CSV to generate in ${BASE_DIR}/generated/${CSV_NAME}/ !"; exit 1; fi
+echo "[INFO] ${0##*/} :: CSV to generate: ${CSV_FILE}"
 
 # update the correct file (either in manifests/ or controller-manifests/v${VERSION}/)
 if [[ -d ${SRC_DIR}/v${VERSION} ]]; then
@@ -65,7 +70,7 @@ if [[ -d ${SRC_DIR}/v${VERSION} ]]; then
 else
   CSV_FILE_ORIG=$(find ${SRC_DIR}/ -maxdepth 2 -name "${CSV_FILE##*/}" | grep -v generated | sort | tail -1)
 fi
-echo "[INFO] CSV to update:   ${BASE_DIR}/${CSV_FILE_ORIG}"
+echo "[INFO] ${0##*/} :: CSV to update:   ${BASE_DIR}/${CSV_FILE_ORIG}"
 
 ${SCRIPTS_DIR}/buildDigestMap.sh -w ${BASE_DIR} -c ${CSV_FILE} -t ${TAG} -v ${VERSION} ${QUIET}
 
@@ -73,13 +78,16 @@ ${SCRIPTS_DIR}/buildDigestMap.sh -w ${BASE_DIR} -c ${CSV_FILE} -t ${TAG} -v ${VE
 names=" "
 count=1
 RELATED_IMAGES='. * { spec : { relatedImages: [ '
-if [[ ! "${QUIET}" ]]; then cat ${BASE_DIR}/generated/digests-mapping.txt; fi
+# if [[ ! "${QUIET}" ]]; then cat ${BASE_DIR}/generated/digests-mapping.txt; fi
 for mapping in $(cat ${BASE_DIR}/generated/digests-mapping.txt)
 do
   source=$(echo "${mapping}" | sed -e 's/\(.*\)=.*/\1/')
   dest=$(echo "${mapping}" | sed -e 's/.*=\(.*\)/\1/')
-  sed -i -e "s;${source};${dest};" ${CSV_FILE}
-  name=$(echo "${dest}" | sed -e 's;.*/\([^\/][^\/]*\)@.*;\1;')
+  if [[ $source ]] && [[ $dest ]]; then 
+    sed -i -e "s;${source};${dest};" ${CSV_FILE}
+  fi
+  name=$(echo "${dest}" | sed -r -e 's;.*/([^/]+)/([^/]+)@.*;\1-\2;')
+  echo "[INFO] ${0##*/} :: Map $name = $dest"
   nameWithSpaces=" ${name} "
   if [[ "${names}" != *${nameWithSpaces}* ]]; then
     if [ "${names}" != " " ]; then
@@ -97,7 +105,7 @@ rm -f ${CSV_FILE}.old
 
 # update original file with generated changes
 mv "${CSV_FILE}" "${CSV_FILE_ORIG}"
-echo "[INFO] CSV updated: ${CSV_FILE_ORIG}"
+echo "[INFO] ${0##*/} :: CSV updated: ${CSV_FILE_ORIG}"
 
 # cleanup
 rm -fr ${BASE_DIR}/generated

--- a/build/scripts/buildDigestMap.sh
+++ b/build/scripts/buildDigestMap.sh
@@ -16,10 +16,10 @@ QUIET=""
 
 PODMAN=$(command -v podman)
 if [[ ! -x $PODMAN ]]; then
-  echo "[WARNING] podman is not installed."
+  echo "[WARNING] ${0##*/} :: podman is not installed."
   PODMAN=$(command -v docker)
   if [[ ! -x $PODMAN ]]; then
-    echo "[ERROR] docker is not installed. Aborting."; exit 1
+    echo "[ERROR] ${0##*/} :: docker is not installed. Aborting."; exit 1
   fi
 fi
 command -v yq >/dev/null 2>&1 || { echo "yq is not installed. Aborting."; exit 1; }
@@ -29,16 +29,16 @@ checkVersion() {
     #echo "[INFO] $3 version $2 >= $1, can proceed."
     true
   else 
-    echo "[ERROR] Must install $3 version >= $1"
+    echo "[ERROR] ${0##*/} :: Must install $3 version >= $1"
     exit 1
   fi
 }
 checkVersion 1.1 "$(skopeo --version | sed -e "s/skopeo version //")" skopeo
 
 usage () {
-	echo "Usage:   $0 [-w WORKDIR] -c [/path/to/csv.yaml] "
-	echo "Example: $0 -w $(pwd) -c  $(pwd)/generated/eclipse-che-preview-openshift/7.9.0/eclipse-che-preview-openshift.v7.9.0.clusterserviceversion.yaml -t 7.9.0"
-	echo "Example: $0 -w $(pwd) -c  $(pwd)/generated/codeready-workspaces/v2.1.1/codeready-workspaces.csv.yaml -t 2.1"
+	echo "Usage:   ${0##*/} [-w WORKDIR] -c [/path/to/csv.yaml] "
+	echo "Example: ${0##*/} -w $(pwd) -c  $(pwd)/generated/eclipse-che-preview-openshift/7.9.0/eclipse-che-preview-openshift.v7.9.0.clusterserviceversion.yaml -t 7.9.0"
+	echo "Example: ${0##*/} -w $(pwd) -c  $(pwd)/generated/codeready-workspaces/v2.1.1/codeready-workspaces.csv.yaml -t 2.1"
 }
 
 if [[ $# -lt 1 ]]; then usage; exit; fi
@@ -58,52 +58,66 @@ if [[ ! $CSV ]] || [[ ! $TAG ]]; then usage; exit 1; fi
 
 mkdir -p ${BASE_DIR}/generated
 
-echo "[INFO] Get images from CSV ${CSV}"
+echo "[INFO] ${0##*/} :: Get images from CSV ${CSV}"
 
-IMAGE_LIST=$(yq -r '.spec.install.spec.deployments[].spec.template.spec.containers[].env[] | select(.name | test("RELATED_IMAGE_.*"; "g")) | .value' "${CSV}")
+IMAGE_LIST=$(yq -r '.spec.install.spec.deployments[].spec.template.spec.containers[].env[] | select(.name | test("RELATED_IMAGE_.*"; "g")) | .value' "${CSV}" | sort | uniq)
 OPERATOR_IMAGE=$(yq -r '.spec.install.spec.deployments[].spec.template.spec.containers[].image' "${CSV}")
 
 REGISTRY_LIST=$(yq -r '.spec.install.spec.deployments[].spec.template.spec.containers[].env[] | select(.name | test("RELATED_IMAGE_.*_registry"; "g")) | .value' "${CSV}")
+# echo "[DEBUG] ${0##*/} :: REGISTRY_LIST = ${REGISTRY_LIST}"
 REGISTRY_IMAGES_ALL=""
-for registry in ${REGISTRY_LIST}; do
-  registry="${registry/\@sha256:*/:${TAG}}" # remove possible existing @sha256:... and use current tag instead
-  # echo -n "[INFO] Pull container ${registry} ..."
-  ${PODMAN} pull ${registry} ${QUIET}
 
-  REGISTRY_IMAGES="$(${PODMAN} run --rm  --entrypoint /bin/sh  ${registry} -c "cat /var/www/html/*/external_images.txt")"
-  echo "[INFO] Found $(echo "${REGISTRY_IMAGES}" | wc -l) images in registry"
+getExternalImagesFromRegistry()
+{
+  thisReg=$1
+  ${PODMAN} pull ${thisReg} ${QUIET} 2>&1 | grep -v "Not found" 
+  REGISTRY_IMAGES="$(${PODMAN} run --rm  --entrypoint /bin/sh  ${thisReg} -c "cat /var/www/html/*/external_images.txt")"
+}
+
+for registry in ${REGISTRY_LIST}; do
+  REGISTRY_IMAGES=""
+  registry="${registry/\@sha256:*/:${TAG}}" # remove possible existing @sha256:... and use current tag instead
+  getExternalImagesFromRegistry $registry
+  if [[ ! ${REGISTRY_IMAGES} ]]; then
+    registryalt=$(echo $registry | sed -r -e "s#registry.redhat.io/codeready-workspaces/#registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-#g")
+    getExternalImagesFromRegistry $registryalt
+  fi
+  echo "[INFO] ${0##*/} :: Found $(echo "${REGISTRY_IMAGES}" grep -v "Not found" | wc -l) images in registry"
   REGISTRY_IMAGES_ALL="${REGISTRY_IMAGES_ALL} ${REGISTRY_IMAGES}"
 done
 
+REGISTRY_IMAGES_ALL=$(tr ' ' '\n' <<< "${OPERATOR_IMAGE} ${IMAGE_LIST} ${REGISTRY_IMAGES_ALL}" | sort | uniq)
+# for image in ${REGISTRY_IMAGES_ALL}; do echo $image; done
+
 rm -Rf ${BASE_DIR}/generated/digests-mapping.txt
 touch ${BASE_DIR}/generated/digests-mapping.txt
-for image in ${OPERATOR_IMAGE} ${IMAGE_LIST} ${REGISTRY_IMAGES_ALL}; do
+for image in ${REGISTRY_IMAGES_ALL}; do
   case ${image} in
-    *@sha256:*)
-      withDigest="${image}";;
-    *@)
+    *@*)
       continue;;
     *)
       # for other build methods or for falling back to other registries when not found, can apply transforms here
       orig_image="${image}"
+      alt_image=""
+      digest=""
       if [[ -x ${SCRIPTS_DIR}/buildDigestMapAlternateURLs.sh ]]; then
         . ${SCRIPTS_DIR}/buildDigestMapAlternateURLs.sh
       fi
       if [[ ${digest} ]]; then
-        if [[ ! "${QUIET}" ]]; then echo -n "[INFO] + Got digest "; fi
+        if [[ ! "${QUIET}" ]]; then echo -n "[INFO] ${0##*/} :: * Got digest "; fi
         echo "    $digest # ${image}"
       else
-        if [[ ! "${QUIET}" ]]; then echo -n "[INFO] - Get digest for ${image}"; fi
+        if [[ ! "${QUIET}" ]]; then echo "[INFO] ${0##*/} :: - Get digest for ${image}"; fi
         image="${orig_image}"
         ARCH_OVERRIDE="" # optional override so that an image without amd64 won't return a failure when searching on amd64 arch machines
         if [[ ${image} == *"-openj9"* ]]; then
           ARCH_OVERRIDE="--override-arch s390x"
         fi
         digest="$(skopeo ${ARCH_OVERRIDE} inspect --tls-verify=false docker://${image} 2>/dev/null | jq -r '.Digest')"
-        if [[ ! "${QUIET}" ]]; then echo -n "[INFO] - Got digest "; fi
+        if [[ ! "${QUIET}" ]]; then echo -n "[INFO] ${0##*/} :: = Got digest "; fi
         echo "    $digest # ${orig_image}"
         if [[ ! ${digest} ]]; then
-          echo "[ERROR] Could not retrieve digest for '${orig_image}' or '${alt_image}': fail!"; exit 1
+          echo "[ERROR] ${0##*/} :: Could not retrieve digest for '${orig_image}' or '${alt_image}': fail!"; exit 1
         fi
       fi
       withoutTag="$(echo "${image}" | sed -e 's/^\(.*\):[^:]*$/\1/')"
@@ -112,9 +126,12 @@ for image in ${OPERATOR_IMAGE} ${IMAGE_LIST} ${REGISTRY_IMAGES_ALL}; do
   dots="${withDigest//[^\.]}"
   separators="${withDigest//[^\/]}"
   if [ "${#separators}" == "1" ] && [ "${#dots}" == "0" ]; then
-    echo "[WARN] Add 'docker.io/' prefix to $image"
+    echo "[WARN] ${0##*/} :: Add 'docker.io/' prefix to $image"
     withDigest="docker.io/${withDigest}"
   fi
 
   echo "${image}=${withDigest}" >> ${BASE_DIR}/generated/digests-mapping.txt
 done
+
+cat ${BASE_DIR}/generated/digests-mapping.txt | sort | uniq > ${BASE_DIR}/generated/digests-mapping.txt2
+mv ${BASE_DIR}/generated/digests-mapping.txt2 ${BASE_DIR}/generated/digests-mapping.txt

--- a/build/scripts/buildDigestMapAlternateURLs.sh
+++ b/build/scripts/buildDigestMapAlternateURLs.sh
@@ -1,4 +1,3 @@
-        if [[ ! "${QUIET}" ]]; then echo -n "[INFO] + Get digest for "; fi
         tmpfile=$(mktemp)
         echo ${image} | sed -r \
             `# for plugin & devfile registries, use internal Brew versions` \
@@ -9,11 +8,11 @@
             > ${tmpfile}
         alt_image=$(cat ${tmpfile})
         rm -f ${tmpfile}
-        if [[ ! "${QUIET}" ]]; then 
-          if [[ "${alt_image}" != "${image}" ]]; then echo "${alt_image} (${image})"; else echo "${alt_image}"; fi
+        if [[ "${alt_image}" != "${image}" ]]; then
+          if [[ ! "${QUIET}" ]]; then echo "[INFO] ${0##*/} :: + Get digest for ${alt_image} (${image})"; fi
+          ARCH_OVERRIDE="" # optional override so that an image without amd64 won't return a failure when searching on amd64 arch machines
+          if [[ ${image} == *"-openj9"* ]]; then
+            ARCH_OVERRIDE="--override-arch s390x"
+          fi
+          digest="$(skopeo ${ARCH_OVERRIDE} inspect --tls-verify=false docker://${alt_image} 2>/dev/null | jq -r '.Digest')"
         fi
-        ARCH_OVERRIDE="" # optional override so that an image without amd64 won't return a failure when searching on amd64 arch machines
-        if [[ ${image} == *"-openj9"* ]]; then
-          ARCH_OVERRIDE="--override-arch s390x"
-        fi
-        digest="$(skopeo ${ARCH_OVERRIDE} inspect --tls-verify=false docker://${alt_image} 2>/dev/null | jq -r '.Digest')"

--- a/build/scripts/insert-related-images-to-csv.sh
+++ b/build/scripts/insert-related-images-to-csv.sh
@@ -95,6 +95,7 @@ done
 # replace external crw refs with internal ones
 sed -r -i $CSVFILE \
   -e "s@registry.access.redhat.com/ubi8-minimal@registry.redhat.io/ubi8-minimal@g"
+  # CRW-1237 temporarily disable switching to registry-proxy URLs - might have to re-enable these if osbs application broken
   # -e "s@registry.redhat.io/codeready-workspaces/@registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-@g#" \
   # -e "s@registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-crw-2-rhel8-operator@registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@g" \
 

--- a/build/scripts/insert-related-images-to-csv.sh
+++ b/build/scripts/insert-related-images-to-csv.sh
@@ -62,13 +62,13 @@ CONTAINERS_UNIQ=()
 for c in $CONTAINERS; do if [[ ! "${CONTAINERS_UNIQ[@]}" =~ "${c}" ]]; then CONTAINERS_UNIQ+=($c); fi; done
 IFS=$'\n' CONTAINERS=($(sort <<<"${CONTAINERS_UNIQ[*]}")); unset IFS
 
+# same method used in both insert-related-images-to-csv.sh and sync-che-olm-to-crw-olm.sh
 insertEnvVar()
 {
-  echo " - $updateName = $updateVal"
+  echo "[INFO] ${0##*/} :: $updateName = $updateVal"
   cat $CSVFILE | yq -Y --arg updateName "${updateName}" --arg updateVal "${updateVal}" \
     '.spec.install.spec.deployments[].spec.template.spec.containers[].env += [{"name": $updateName, "value": $updateVal}]' \
     > ${CSVFILE}.2; mv ${CSVFILE}.2 ${CSVFILE}
-
 }
 
 CSVFILE=${TARGETDIR}/manifests/codeready-workspaces.csv.yaml
@@ -94,9 +94,9 @@ done
 
 # replace external crw refs with internal ones
 sed -r -i $CSVFILE \
-  -e "s@registry.redhat.io/codeready-workspaces/@registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-@g#" \
-  -e "s@registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-crw-2-rhel8-operator@registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@g" \
   -e "s@registry.access.redhat.com/ubi8-minimal@registry.redhat.io/ubi8-minimal@g"
+  # -e "s@registry.redhat.io/codeready-workspaces/@registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-@g#" \
+  # -e "s@registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-crw-2-rhel8-operator@registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@g" \
 
 # echo list of RELATED_IMAGE_ entries after adding them above
 # cat $CSVFILE | grep RELATED_IMAGE_ -A1

--- a/controller-manifests/v2.4.0/codeready-workspaces.csv.yaml
+++ b/controller-manifests/v2.4.0/codeready-workspaces.csv.yaml
@@ -49,8 +49,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools, OpenShift Optional
     certified: "true"
-    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
-    createdAt: "2020-09-23T17:51:36+00:00"
+    containerImage: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
+    createdAt: "2020-09-23T18:26:05+00:00"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: openshift-workspaces
@@ -297,49 +297,49 @@ spec:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: RELATED_IMAGE_che_server
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8@sha256:63bf304cd04576048012693e7e8544a5a703790f99551554a75798bc799b112b
+                        value: registry.redhat.io/codeready-workspaces/server-rhel8@sha256:63bf304cd04576048012693e7e8544a5a703790f99551554a75798bc799b112b
                       - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8@sha256:8afecd5b0edc7734532ee76ff9eac1fc4814d8aaa6c9be440a2a88a20c014e4e
+                        value: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8@sha256:8afecd5b0edc7734532ee76ff9eac1fc4814d8aaa6c9be440a2a88a20c014e4e
                       - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8@sha256:d0eebf2c8b460adb75dc6bc5200aa9fd40d030b7b17c6b1c3b9d3c879f4652ee
+                        value: registry.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8@sha256:d0eebf2c8b460adb75dc6bc5200aa9fd40d030b7b17c6b1c3b9d3c879f4652ee
                       - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8@sha256:cff23432d1d397bbbc7df65be9d6ddf4a97a3ef1801708bb7bb7d2fa72dbcce3
+                        value: registry.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8@sha256:cff23432d1d397bbbc7df65be9d6ddf4a97a3ef1801708bb7bb7d2fa72dbcce3
                       - name: RELATED_IMAGE_codeready_workspaces_machineexec
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
+                        value: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java11
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
+                        value: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_openj9
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
+                        value: registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_ppc64le
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
+                        value: registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_s390x
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
+                        value: registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java8
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
+                        value: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_openj9
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
+                        value: registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_ppc64le
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
+                        value: registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_s390x
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
+                        value: registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_kubernetes
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
+                        value: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_openshift
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
+                        value: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_cpp
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
+                        value: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_dotnet
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
+                        value: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_golang
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
+                        value: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_php
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
+                        value: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
                       - name: RELATED_IMAGE_codeready_workspaces_theia
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
+                        value: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
                       - name: RELATED_IMAGE_codeready_workspaces_theia_endpoint
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
+                        value: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
                       - name: RELATED_IMAGE_devfile_registry
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
+                        value: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
                       - name: RELATED_IMAGE_jboss_eap_7_eap73_openjdk8_openshift_rhel7
                         value: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7@sha256:24dea0cfc154a23c1aeb6b46ade182d0f981362f36b7e6fb9c7d8531ac639fe0
                       - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openj9_11_openshift
@@ -357,7 +357,7 @@ spec:
                       - name: RELATED_IMAGE_keycloak_s390x
                         value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
                       - name: RELATED_IMAGE_plugin_registry
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
+                        value: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
                       - name: RELATED_IMAGE_postgres
                         value: registry.redhat.io/rhel8/postgresql-96@sha256:fdc2398a25530547354714f2538c691d91b700e0cedef5361a3e7d96ddfd4e11
                       - name: RELATED_IMAGE_pvc_jobs
@@ -368,7 +368,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
+                    image: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
                     imagePullPolicy: Always
                     name: codeready-operator
                     ports:
@@ -486,120 +486,87 @@ spec:
   replaces: crwoperator.v2.3.0
   version: 2.4.0
   relatedImages:
-    - name: codeready-workspaces-operator
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:2.4
-    - name: codeready-workspaces-server-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8@sha256:63bf304cd04576048012693e7e8544a5a703790f99551554a75798bc799b112b
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8:2.4
-    - name: codeready-workspaces-jwtproxy-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8@sha256:8afecd5b0edc7734532ee76ff9eac1fc4814d8aaa6c9be440a2a88a20c014e4e
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8:2.4
-    - name: codeready-workspaces-pluginbroker-artifacts-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8@sha256:d0eebf2c8b460adb75dc6bc5200aa9fd40d030b7b17c6b1c3b9d3c879f4652ee
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8:2.4
-    - name: codeready-workspaces-pluginbroker-metadata-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8@sha256:cff23432d1d397bbbc7df65be9d6ddf4a97a3ef1801708bb7bb7d2fa72dbcce3
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8:2.4
-    - name: codeready-workspaces-machineexec-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8:2.4
-    - name: codeready-workspaces-plugin-java11-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8:2.4
-    - name: codeready-workspaces-plugin-java11-openj9-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.4
-    - name: codeready-workspaces-plugin-java8-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8:2.4
-    - name: codeready-workspaces-plugin-java8-openj9-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.4
-    - name: codeready-workspaces-plugin-kubernetes-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8:2.4
-    - name: codeready-workspaces-plugin-openshift-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8:2.4
-    - name: codeready-workspaces-stacks-cpp-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8:2.4
-    - name: codeready-workspaces-stacks-dotnet-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8:2.4
-    - name: codeready-workspaces-stacks-golang-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8:2.4
-    - name: codeready-workspaces-stacks-php-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8:2.4
-    - name: codeready-workspaces-theia-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8:2.4
-    - name: codeready-workspaces-theia-endpoint-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8:2.4
+    - name: codeready-workspaces-crw-2-rhel8-operator
+      image: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
+      # tag: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:2.4
     - name: codeready-workspaces-devfileregistry-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8:2.4
-    - name: eap73-openjdk8-openshift-rhel7
+      image: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
+      # tag: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:2.4
+    - name: codeready-workspaces-jwtproxy-rhel8
+      image: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8@sha256:8afecd5b0edc7734532ee76ff9eac1fc4814d8aaa6c9be440a2a88a20c014e4e
+      # tag: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8:2.4
+    - name: codeready-workspaces-machineexec-rhel8
+      image: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
+      # tag: registry.redhat.io/codeready-workspaces/machineexec-rhel8:2.4
+    - name: codeready-workspaces-pluginbroker-artifacts-rhel8
+      image: registry.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8@sha256:d0eebf2c8b460adb75dc6bc5200aa9fd40d030b7b17c6b1c3b9d3c879f4652ee
+      # tag: registry.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8:2.4
+    - name: codeready-workspaces-pluginbroker-metadata-rhel8
+      image: registry.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8@sha256:cff23432d1d397bbbc7df65be9d6ddf4a97a3ef1801708bb7bb7d2fa72dbcce3
+      # tag: registry.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8:2.4
+    - name: codeready-workspaces-plugin-java11-openj9-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8:2.4
+    - name: codeready-workspaces-plugin-java11-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.4
+    - name: codeready-workspaces-plugin-java8-openj9-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8:2.4
+    - name: codeready-workspaces-plugin-java8-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.4
+    - name: codeready-workspaces-plugin-kubernetes-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
+      # tag: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8:2.4
+    - name: codeready-workspaces-plugin-openshift-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
+      # tag: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.4
+    - name: codeready-workspaces-pluginregistry-rhel8
+      image: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
+      # tag: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8:2.4
+    - name: codeready-workspaces-server-rhel8
+      image: registry.redhat.io/codeready-workspaces/server-rhel8@sha256:63bf304cd04576048012693e7e8544a5a703790f99551554a75798bc799b112b
+      # tag: registry.redhat.io/codeready-workspaces/server-rhel8:2.4
+    - name: codeready-workspaces-stacks-cpp-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
+      # tag: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8:2.4
+    - name: codeready-workspaces-stacks-dotnet-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
+      # tag: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8:2.4
+    - name: codeready-workspaces-stacks-golang-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
+      # tag: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8:2.4
+    - name: codeready-workspaces-stacks-php-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
+      # tag: registry.redhat.io/codeready-workspaces/stacks-php-rhel8:2.4
+    - name: codeready-workspaces-theia-endpoint-rhel8
+      image: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
+      # tag: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8:2.4
+    - name: codeready-workspaces-theia-rhel8
+      image: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
+      # tag: registry.redhat.io/codeready-workspaces/theia-rhel8:2.4
+    - name: jboss-eap-7-eap73-openjdk8-openshift-rhel7
       image: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7@sha256:24dea0cfc154a23c1aeb6b46ade182d0f981362f36b7e6fb9c7d8531ac639fe0
       # tag: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.1
-    - name: eap-xp1-openj9-11-openshift-rhel8
+    - name: jboss-eap-7-eap-xp1-openj9-11-openshift-rhel8
       image: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8@sha256:d6a7bdbf4726fe0e0e54c0bce9b2257bbd2a165c37cb4ec68e1f994716ffb15c
       # tag: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8:1.0-12
-    - name: eap-xp1-openjdk11-openshift-rhel8
+    - name: jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8
       image: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8@sha256:94e1cd4eb4196a358e301c1992663258c0016c80247f507fd1c39cf9a73da833
       # tag: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0-3
-    - name: sso74-openshift-rhel8
-      image: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:ec6801343eb1ca085154d8d7481552f2e9debc414125413d25e42216aa5922af
-      # tag: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
-    - name: sso74-openj9-openshift-rhel8
-      image: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
-      # tag: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
-    - name: codeready-workspaces-pluginregistry-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8:2.4
-    - name: postgresql-96
+    - name: rhel8-postgresql-96
       image: registry.redhat.io/rhel8/postgresql-96@sha256:fdc2398a25530547354714f2538c691d91b700e0cedef5361a3e7d96ddfd4e11
       # tag: registry.redhat.io/rhel8/postgresql-96:1
-    - name: ubi8-minimal
-      image: registry.redhat.io/ubi8-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
-      # tag: registry.redhat.io/ubi8-minimal:8.2
-    - name: mongodb-36-rhel7
+    - name: rhscl-mongodb-36-rhel7
       image: registry.redhat.io/rhscl/mongodb-36-rhel7@sha256:9f799d356d7d2e442bde9d401b720600fd9059a3d8eefea6f3b2ffa721c0dc73
       # tag: registry.redhat.io/rhscl/mongodb-36-rhel7:1-50
-    - name: plugin-java11-rhel8
-      image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
-      # tag: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
-    - name: plugin-java8-rhel8
-      image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
-      # tag: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
-    - name: stacks-cpp-rhel8
-      image: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
-      # tag: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
-    - name: stacks-dotnet-rhel8
-      image: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
-      # tag: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
-    - name: stacks-golang-rhel8
-      image: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
-      # tag: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
-    - name: stacks-php-rhel8
-      image: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
-      # tag: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
-    - name: machineexec-rhel8
-      image: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
-      # tag: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
-    - name: plugin-kubernetes-rhel8
-      image: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
-      # tag: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
-    - name: plugin-openshift-rhel8
-      image: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
-      # tag: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
-    - name: theia-endpoint-rhel8
-      image: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
-      # tag: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
-    - name: theia-rhel8
-      image: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
-      # tag: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
+    - name: rh-sso-7-sso74-openj9-openshift-rhel8
+      image: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
+      # tag: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
+    - name: rh-sso-7-sso74-openshift-rhel8
+      image: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:ec6801343eb1ca085154d8d7481552f2e9debc414125413d25e42216aa5922af
+      # tag: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
+    - name: registry.redhat.io/ubi8-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
+      image: registry.redhat.io/ubi8-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
+      # tag: registry.redhat.io/ubi8-minimal:8.2

--- a/controller-manifests/v2.4.0/codeready-workspaces.csv.yaml
+++ b/controller-manifests/v2.4.0/codeready-workspaces.csv.yaml
@@ -50,7 +50,7 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "true"
     containerImage: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
-    createdAt: "2020-09-23T18:26:05+00:00"
+    createdAt: "2020-09-23T21:31:22+00:00"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: openshift-workspaces
@@ -339,7 +339,7 @@ spec:
                       - name: RELATED_IMAGE_codeready_workspaces_theia_endpoint
                         value: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
                       - name: RELATED_IMAGE_devfile_registry
-                        value: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
+                        value: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:7702adb0ed28b635e45804e87fe5dd98bdd3aa766fed7845a8ce509b91c22e36
                       - name: RELATED_IMAGE_jboss_eap_7_eap73_openjdk8_openshift_rhel7
                         value: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7@sha256:24dea0cfc154a23c1aeb6b46ade182d0f981362f36b7e6fb9c7d8531ac639fe0
                       - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openj9_11_openshift
@@ -357,7 +357,7 @@ spec:
                       - name: RELATED_IMAGE_keycloak_s390x
                         value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
                       - name: RELATED_IMAGE_plugin_registry
-                        value: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
+                        value: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:9f37917122c20fc83e6558a5484efab42650958b513a22920f449f948e50cd51
                       - name: RELATED_IMAGE_postgres
                         value: registry.redhat.io/rhel8/postgresql-96@sha256:fdc2398a25530547354714f2538c691d91b700e0cedef5361a3e7d96ddfd4e11
                       - name: RELATED_IMAGE_pvc_jobs
@@ -490,7 +490,7 @@ spec:
       image: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
       # tag: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:2.4
     - name: codeready-workspaces-devfileregistry-rhel8
-      image: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
+      image: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:7702adb0ed28b635e45804e87fe5dd98bdd3aa766fed7845a8ce509b91c22e36
       # tag: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:2.4
     - name: codeready-workspaces-jwtproxy-rhel8
       image: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8@sha256:8afecd5b0edc7734532ee76ff9eac1fc4814d8aaa6c9be440a2a88a20c014e4e
@@ -523,7 +523,7 @@ spec:
       image: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
       # tag: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.4
     - name: codeready-workspaces-pluginregistry-rhel8
-      image: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
+      image: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:9f37917122c20fc83e6558a5484efab42650958b513a22920f449f948e50cd51
       # tag: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8:2.4
     - name: codeready-workspaces-server-rhel8
       image: registry.redhat.io/codeready-workspaces/server-rhel8@sha256:63bf304cd04576048012693e7e8544a5a703790f99551554a75798bc799b112b

--- a/manifests/codeready-workspaces.csv.yaml
+++ b/manifests/codeready-workspaces.csv.yaml
@@ -49,8 +49,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Developer Tools, OpenShift Optional
     certified: "true"
-    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
-    createdAt: "2020-09-23T17:51:36+00:00"
+    containerImage: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
+    createdAt: "2020-09-23T18:26:05+00:00"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: openshift-workspaces
@@ -297,49 +297,49 @@ spec:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: RELATED_IMAGE_che_server
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8@sha256:63bf304cd04576048012693e7e8544a5a703790f99551554a75798bc799b112b
+                        value: registry.redhat.io/codeready-workspaces/server-rhel8@sha256:63bf304cd04576048012693e7e8544a5a703790f99551554a75798bc799b112b
                       - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8@sha256:8afecd5b0edc7734532ee76ff9eac1fc4814d8aaa6c9be440a2a88a20c014e4e
+                        value: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8@sha256:8afecd5b0edc7734532ee76ff9eac1fc4814d8aaa6c9be440a2a88a20c014e4e
                       - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8@sha256:d0eebf2c8b460adb75dc6bc5200aa9fd40d030b7b17c6b1c3b9d3c879f4652ee
+                        value: registry.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8@sha256:d0eebf2c8b460adb75dc6bc5200aa9fd40d030b7b17c6b1c3b9d3c879f4652ee
                       - name: RELATED_IMAGE_che_workspace_plugin_broker_metadata
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8@sha256:cff23432d1d397bbbc7df65be9d6ddf4a97a3ef1801708bb7bb7d2fa72dbcce3
+                        value: registry.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8@sha256:cff23432d1d397bbbc7df65be9d6ddf4a97a3ef1801708bb7bb7d2fa72dbcce3
                       - name: RELATED_IMAGE_codeready_workspaces_machineexec
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
+                        value: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java11
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
+                        value: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_openj9
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
+                        value: registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_ppc64le
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
+                        value: registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java11_s390x
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
+                        value: registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java8
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
+                        value: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_openj9
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
+                        value: registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_ppc64le
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
+                        value: registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_java8_s390x
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
+                        value: registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_kubernetes
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
+                        value: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
                       - name: RELATED_IMAGE_codeready_workspaces_plugin_openshift
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
+                        value: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_cpp
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
+                        value: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_dotnet
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
+                        value: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_golang
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
+                        value: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
                       - name: RELATED_IMAGE_codeready_workspaces_stacks_php
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
+                        value: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
                       - name: RELATED_IMAGE_codeready_workspaces_theia
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
+                        value: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
                       - name: RELATED_IMAGE_codeready_workspaces_theia_endpoint
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
+                        value: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
                       - name: RELATED_IMAGE_devfile_registry
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
+                        value: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
                       - name: RELATED_IMAGE_jboss_eap_7_eap73_openjdk8_openshift_rhel7
                         value: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7@sha256:24dea0cfc154a23c1aeb6b46ade182d0f981362f36b7e6fb9c7d8531ac639fe0
                       - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openj9_11_openshift
@@ -357,7 +357,7 @@ spec:
                       - name: RELATED_IMAGE_keycloak_s390x
                         value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
                       - name: RELATED_IMAGE_plugin_registry
-                        value: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
+                        value: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
                       - name: RELATED_IMAGE_postgres
                         value: registry.redhat.io/rhel8/postgresql-96@sha256:fdc2398a25530547354714f2538c691d91b700e0cedef5361a3e7d96ddfd4e11
                       - name: RELATED_IMAGE_pvc_jobs
@@ -368,7 +368,7 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                    image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
+                    image: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
                     imagePullPolicy: Always
                     name: codeready-operator
                     ports:
@@ -486,120 +486,87 @@ spec:
   replaces: crwoperator.v2.3.0
   version: 2.4.0
   relatedImages:
-    - name: codeready-workspaces-operator
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator:2.4
-    - name: codeready-workspaces-server-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8@sha256:63bf304cd04576048012693e7e8544a5a703790f99551554a75798bc799b112b
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-server-rhel8:2.4
-    - name: codeready-workspaces-jwtproxy-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8@sha256:8afecd5b0edc7734532ee76ff9eac1fc4814d8aaa6c9be440a2a88a20c014e4e
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-jwtproxy-rhel8:2.4
-    - name: codeready-workspaces-pluginbroker-artifacts-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8@sha256:d0eebf2c8b460adb75dc6bc5200aa9fd40d030b7b17c6b1c3b9d3c879f4652ee
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-artifacts-rhel8:2.4
-    - name: codeready-workspaces-pluginbroker-metadata-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8@sha256:cff23432d1d397bbbc7df65be9d6ddf4a97a3ef1801708bb7bb7d2fa72dbcce3
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginbroker-metadata-rhel8:2.4
-    - name: codeready-workspaces-machineexec-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-machineexec-rhel8:2.4
-    - name: codeready-workspaces-plugin-java11-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-rhel8:2.4
-    - name: codeready-workspaces-plugin-java11-openj9-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java11-openj9-rhel8:2.4
-    - name: codeready-workspaces-plugin-java8-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-rhel8:2.4
-    - name: codeready-workspaces-plugin-java8-openj9-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-java8-openj9-rhel8:2.4
-    - name: codeready-workspaces-plugin-kubernetes-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-kubernetes-rhel8:2.4
-    - name: codeready-workspaces-plugin-openshift-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-plugin-openshift-rhel8:2.4
-    - name: codeready-workspaces-stacks-cpp-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-cpp-rhel8:2.4
-    - name: codeready-workspaces-stacks-dotnet-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-dotnet-rhel8:2.4
-    - name: codeready-workspaces-stacks-golang-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-golang-rhel8:2.4
-    - name: codeready-workspaces-stacks-php-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-stacks-php-rhel8:2.4
-    - name: codeready-workspaces-theia-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-rhel8:2.4
-    - name: codeready-workspaces-theia-endpoint-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-theia-endpoint-rhel8:2.4
+    - name: codeready-workspaces-crw-2-rhel8-operator
+      image: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
+      # tag: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:2.4
     - name: codeready-workspaces-devfileregistry-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-devfileregistry-rhel8:2.4
-    - name: eap73-openjdk8-openshift-rhel7
+      image: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
+      # tag: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:2.4
+    - name: codeready-workspaces-jwtproxy-rhel8
+      image: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8@sha256:8afecd5b0edc7734532ee76ff9eac1fc4814d8aaa6c9be440a2a88a20c014e4e
+      # tag: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8:2.4
+    - name: codeready-workspaces-machineexec-rhel8
+      image: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
+      # tag: registry.redhat.io/codeready-workspaces/machineexec-rhel8:2.4
+    - name: codeready-workspaces-pluginbroker-artifacts-rhel8
+      image: registry.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8@sha256:d0eebf2c8b460adb75dc6bc5200aa9fd40d030b7b17c6b1c3b9d3c879f4652ee
+      # tag: registry.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8:2.4
+    - name: codeready-workspaces-pluginbroker-metadata-rhel8
+      image: registry.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8@sha256:cff23432d1d397bbbc7df65be9d6ddf4a97a3ef1801708bb7bb7d2fa72dbcce3
+      # tag: registry.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8:2.4
+    - name: codeready-workspaces-plugin-java11-openj9-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8@sha256:27a71612f9bd3bee77adb4e164c44c61cf5085458d592215b2fe74c55d11abc6
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java11-openj9-rhel8:2.4
+    - name: codeready-workspaces-plugin-java11-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8:2.4
+    - name: codeready-workspaces-plugin-java8-openj9-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8@sha256:14f2774e92b70d85280e506f81e2ea9a89c26490fd53a4421df8a694bd944d2d
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java8-openj9-rhel8:2.4
+    - name: codeready-workspaces-plugin-java8-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
+      # tag: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8:2.4
+    - name: codeready-workspaces-plugin-kubernetes-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
+      # tag: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8:2.4
+    - name: codeready-workspaces-plugin-openshift-rhel8
+      image: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
+      # tag: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.4
+    - name: codeready-workspaces-pluginregistry-rhel8
+      image: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
+      # tag: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8:2.4
+    - name: codeready-workspaces-server-rhel8
+      image: registry.redhat.io/codeready-workspaces/server-rhel8@sha256:63bf304cd04576048012693e7e8544a5a703790f99551554a75798bc799b112b
+      # tag: registry.redhat.io/codeready-workspaces/server-rhel8:2.4
+    - name: codeready-workspaces-stacks-cpp-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
+      # tag: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8:2.4
+    - name: codeready-workspaces-stacks-dotnet-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
+      # tag: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8:2.4
+    - name: codeready-workspaces-stacks-golang-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
+      # tag: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8:2.4
+    - name: codeready-workspaces-stacks-php-rhel8
+      image: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
+      # tag: registry.redhat.io/codeready-workspaces/stacks-php-rhel8:2.4
+    - name: codeready-workspaces-theia-endpoint-rhel8
+      image: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
+      # tag: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8:2.4
+    - name: codeready-workspaces-theia-rhel8
+      image: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
+      # tag: registry.redhat.io/codeready-workspaces/theia-rhel8:2.4
+    - name: jboss-eap-7-eap73-openjdk8-openshift-rhel7
       image: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7@sha256:24dea0cfc154a23c1aeb6b46ade182d0f981362f36b7e6fb9c7d8531ac639fe0
       # tag: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.1
-    - name: eap-xp1-openj9-11-openshift-rhel8
+    - name: jboss-eap-7-eap-xp1-openj9-11-openshift-rhel8
       image: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8@sha256:d6a7bdbf4726fe0e0e54c0bce9b2257bbd2a165c37cb4ec68e1f994716ffb15c
       # tag: registry.redhat.io/jboss-eap-7/eap-xp1-openj9-11-openshift-rhel8:1.0-12
-    - name: eap-xp1-openjdk11-openshift-rhel8
+    - name: jboss-eap-7-eap-xp1-openjdk11-openshift-rhel8
       image: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8@sha256:94e1cd4eb4196a358e301c1992663258c0016c80247f507fd1c39cf9a73da833
       # tag: registry.redhat.io/jboss-eap-7/eap-xp1-openjdk11-openshift-rhel8:1.0-3
-    - name: sso74-openshift-rhel8
-      image: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:ec6801343eb1ca085154d8d7481552f2e9debc414125413d25e42216aa5922af
-      # tag: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
-    - name: sso74-openj9-openshift-rhel8
-      image: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
-      # tag: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
-    - name: codeready-workspaces-pluginregistry-rhel8
-      image: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
-      # tag: registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-pluginregistry-rhel8:2.4
-    - name: postgresql-96
+    - name: rhel8-postgresql-96
       image: registry.redhat.io/rhel8/postgresql-96@sha256:fdc2398a25530547354714f2538c691d91b700e0cedef5361a3e7d96ddfd4e11
       # tag: registry.redhat.io/rhel8/postgresql-96:1
-    - name: ubi8-minimal
-      image: registry.redhat.io/ubi8-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
-      # tag: registry.redhat.io/ubi8-minimal:8.2
-    - name: mongodb-36-rhel7
+    - name: rhscl-mongodb-36-rhel7
       image: registry.redhat.io/rhscl/mongodb-36-rhel7@sha256:9f799d356d7d2e442bde9d401b720600fd9059a3d8eefea6f3b2ffa721c0dc73
       # tag: registry.redhat.io/rhscl/mongodb-36-rhel7:1-50
-    - name: plugin-java11-rhel8
-      image: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
-      # tag: registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:e9deebbc320d28a2f425e858ed3dcf87fc67a40f6654d6eb7c2b6feea022b7d6
-    - name: plugin-java8-rhel8
-      image: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
-      # tag: registry.redhat.io/codeready-workspaces/plugin-java8-rhel8@sha256:d04f70c8340abaee1a282b77158d054f4faf2225bc17c79aafb413396c367782
-    - name: stacks-cpp-rhel8
-      image: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
-      # tag: registry.redhat.io/codeready-workspaces/stacks-cpp-rhel8@sha256:56543cfeeeac030821557ac4937db40f6845e874193c79c30267a680f9b2cbe7
-    - name: stacks-dotnet-rhel8
-      image: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
-      # tag: registry.redhat.io/codeready-workspaces/stacks-dotnet-rhel8@sha256:13628110b96de0e516ff2dfa29cdcaee64cd8f8978052c8160c294c332dba9f0
-    - name: stacks-golang-rhel8
-      image: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
-      # tag: registry.redhat.io/codeready-workspaces/stacks-golang-rhel8@sha256:fef91718ccebc4cd9b89999f6b5df83bf3d60fce657f6f44eda092100549af2c
-    - name: stacks-php-rhel8
-      image: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
-      # tag: registry.redhat.io/codeready-workspaces/stacks-php-rhel8@sha256:b75f498954fbe858c74f80a89d132ba3560f40c0f697b0cd9550ed5663078ef6
-    - name: machineexec-rhel8
-      image: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
-      # tag: registry.redhat.io/codeready-workspaces/machineexec-rhel8@sha256:c9bebc895e5fa5a0bd4ecaedfd5384ab75a45a96b6314ba5d4a6f4c1e8e109f9
-    - name: plugin-kubernetes-rhel8
-      image: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
-      # tag: registry.redhat.io/codeready-workspaces/plugin-kubernetes-rhel8@sha256:d87aed64704369a50d1e54a57815b699f74d4efad1401d1a638808e655a37e48
-    - name: plugin-openshift-rhel8
-      image: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
-      # tag: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
-    - name: theia-endpoint-rhel8
-      image: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
-      # tag: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
-    - name: theia-rhel8
-      image: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
-      # tag: registry.redhat.io/codeready-workspaces/theia-rhel8@sha256:78edc9f75680cbe7f63774d9dfbbc505401486a73c8e420380e1d3078bdf9f2a
+    - name: rh-sso-7-sso74-openj9-openshift-rhel8
+      image: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
+      # tag: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4
+    - name: rh-sso-7-sso74-openshift-rhel8
+      image: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8@sha256:ec6801343eb1ca085154d8d7481552f2e9debc414125413d25e42216aa5922af
+      # tag: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4
+    - name: registry.redhat.io/ubi8-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
+      image: registry.redhat.io/ubi8-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187aadb32e89fd83fa455ebaa6
+      # tag: registry.redhat.io/ubi8-minimal:8.2

--- a/manifests/codeready-workspaces.csv.yaml
+++ b/manifests/codeready-workspaces.csv.yaml
@@ -50,7 +50,7 @@ metadata:
     categories: Developer Tools, OpenShift Optional
     certified: "true"
     containerImage: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
-    createdAt: "2020-09-23T18:26:05+00:00"
+    createdAt: "2020-09-23T21:31:22+00:00"
     description: A Kube-native development solution that delivers portable and collaborative
       developer workspaces in OpenShift.
     operatorframework.io/suggested-namespace: openshift-workspaces
@@ -339,7 +339,7 @@ spec:
                       - name: RELATED_IMAGE_codeready_workspaces_theia_endpoint
                         value: registry.redhat.io/codeready-workspaces/theia-endpoint-rhel8@sha256:942e1e6328169508e3fff8fd96c575d7a423339ced17dbf5813d61d1971adaef
                       - name: RELATED_IMAGE_devfile_registry
-                        value: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
+                        value: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:7702adb0ed28b635e45804e87fe5dd98bdd3aa766fed7845a8ce509b91c22e36
                       - name: RELATED_IMAGE_jboss_eap_7_eap73_openjdk8_openshift_rhel7
                         value: registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7@sha256:24dea0cfc154a23c1aeb6b46ade182d0f981362f36b7e6fb9c7d8531ac639fe0
                       - name: RELATED_IMAGE_jboss_eap_7_eap_xp1_openj9_11_openshift
@@ -357,7 +357,7 @@ spec:
                       - name: RELATED_IMAGE_keycloak_s390x
                         value: registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8@sha256:8e6c7874247053df431c25552c6e2edb050b2627ae21907149f419e0d9909135
                       - name: RELATED_IMAGE_plugin_registry
-                        value: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
+                        value: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:9f37917122c20fc83e6558a5484efab42650958b513a22920f449f948e50cd51
                       - name: RELATED_IMAGE_postgres
                         value: registry.redhat.io/rhel8/postgresql-96@sha256:fdc2398a25530547354714f2538c691d91b700e0cedef5361a3e7d96ddfd4e11
                       - name: RELATED_IMAGE_pvc_jobs
@@ -490,7 +490,7 @@ spec:
       image: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:89763ddec38a5925a052fa7ea75fc5a0db39124cada1e2d33b6eba3e32e8a7c6
       # tag: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:2.4
     - name: codeready-workspaces-devfileregistry-rhel8
-      image: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:75422d2d0f2820e4f0c4c9b1e6f6bc4eca702df81f6437b7ceb201a4e3492e33
+      image: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:7702adb0ed28b635e45804e87fe5dd98bdd3aa766fed7845a8ce509b91c22e36
       # tag: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:2.4
     - name: codeready-workspaces-jwtproxy-rhel8
       image: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8@sha256:8afecd5b0edc7734532ee76ff9eac1fc4814d8aaa6c9be440a2a88a20c014e4e
@@ -523,7 +523,7 @@ spec:
       image: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8@sha256:9c43a02b0dd0f66744359c5ccdb1f1780ecd92c3dc31b14d73b553ba763af8ab
       # tag: registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.4
     - name: codeready-workspaces-pluginregistry-rhel8
-      image: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:487941489c197f3165f6f901d22ac1d9d81079db5e048dc33a23beb5a2066814
+      image: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:9f37917122c20fc83e6558a5484efab42650958b513a22920f449f948e50cd51
       # tag: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8:2.4
     - name: codeready-workspaces-server-rhel8
       image: registry.redhat.io/codeready-workspaces/server-rhel8@sha256:63bf304cd04576048012693e7e8544a5a703790f99551554a75798bc799b112b


### PR DESCRIPTION
CRW-1233 fix for redundant entries in csv: remove entries if already a digest (only insert if a tag being converted)

improve console logging so it's more obvious WHICH file is running; dedupe/sort/uniq the list of containers to collect; when checking registries for related images, check osbs if can't find rhec image

CRW-1237 temporarily disable switching to registry-proxy URLs - might have to re-enable these if osbs application broken

Change-Id: Iee5138612d378dba94951a63268ca104da39179b
Signed-off-by: nickboldt <nboldt@redhat.com>

Change-Id: I13374d23a3ac838d5f02a49d1cd3b937de18fa85
Signed-off-by: nickboldt <nboldt@redhat.com>

Change-Id: I978dabd7284a31f3d8bf53a40a8d8fc773fdd6dd
Signed-off-by: nickboldt <nboldt@redhat.com>