### PR TITLE
Adding all arches to CSV file

### DIFF
--- a/build/scripts/sync-che-olm-to-crw-olm.sh
+++ b/build/scripts/sync-che-olm-to-crw-olm.sh
@@ -205,6 +205,7 @@ for CSVFILE in ${TARGETDIR}/manifests/codeready-workspaces.csv.yaml; do
 		-e '/operatorframework.io\/cluster-monitoring:/d' \
 		-e 's|operatorframework.io/suggested-namespace: .+|operatorframework.io/suggested-namespace: openshift-workspaces|' \
 		-e '/operatorframework.io\/suggested-namespace/a \ \ \ \ operatorframework.io/cluster-monitoring: "true"' \
+		-e '/annotations\:/i \ \ labels:\n    operatorframework.io/arch.amd64\: supported\n    operatorframework.io/arch.ppc64le\: supported\n    operatorframework.io/arch.s390x\: supported' \
 		-i "${CSVFILE}"
 	# insert missing cheFlavor annotation
 	if [[ ! $(grep -E '"cheFlavor":"codeready",' "${CSVFILE}") ]]; then 


### PR DESCRIPTION
If a ClusterServiceVersion does not include an arch label, a target architecture is assumed to be amd64
As we need to add support for Power,Z , adding change here

