### PR TITLE
Update service monitor to match the `app.kubernetes.io/component` label

### DIFF
--- a/manifests/servicemonitor.yaml
+++ b/manifests/servicemonitor.yaml
@@ -12,4 +12,4 @@ spec:
     - openshift-workspaces
   selector:
     matchLabels:
-      component: codeready
+      app.kubernetes.io/component: codeready


### PR DESCRIPTION
### What does this PR do?
Update service monitor to match the `app.kubernetes.io/component` label

![image](https://user-images.githubusercontent.com/1461122/111624040-77afb400-87eb-11eb-837f-be3ea2854076.png)

The previous `component` label does not match anymore.
This results in a fact that CRW 2.7 OCP metrics will not be reported to telemeter

### What issues does this PR fix or reference?

Related issue - https://issues.redhat.com/browse/CRW-1668

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
