### PR TITLE
Update service monitor to match the `app.kubernetes.io/component` label

### DIFF
--- a/manifests/servicemonitor.yaml
+++ b/manifests/servicemonitor.yaml
@@ -12,4 +12,4 @@ spec:
     - openshift-workspaces
   selector:
     matchLabels:
-      component: codeready
+      app.kubernetes.io/component: codeready


### PR DESCRIPTION
### What does this PR do?
Update service monitor to match the `app.kubernetes.io/component` label

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1668

the related issue for the `2.7.1` respin - https://issues.redhat.com/browse/CRW-1670

<!-- #### Changelog -->
Update service monitor to match the `app.kubernetes.io/component` label

#### Release Notes
N/A bug-fix

#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
